### PR TITLE
feat: 보드판 정보 API 구현

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
@@ -1,0 +1,64 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.application.mission.dto.request.MissionBoardQuery;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import com.nexters.goalpanzi.domain.common.BaseEntity;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.mission.Mission;
+import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
+import com.nexters.goalpanzi.domain.mission.repository.MissionRepository;
+import com.nexters.goalpanzi.exception.ErrorCode;
+import com.nexters.goalpanzi.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RequiredArgsConstructor
+@Service
+public class MissionBoardService {
+
+    private final MissionRepository missionRepository;
+    private final MissionMemberRepository missionMemberRepository;
+
+    @Transactional
+    public List<MissionBoardResponse> getBoard(final MissionBoardQuery query) {
+        return missionRepository.findById(query.missionId())
+                .map(this::groupByVerificationCount)
+                .map(this::sortByVerifiedAt)
+                .map(this::convertToBoardResponse)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MISSION, query.missionId()));
+    }
+
+    private Map<Integer, List<Member>> groupByVerificationCount(final Mission mission) {
+        Map<Integer, List<Member>> board = initializeBoard(mission.getBoardCount());
+
+        missionMemberRepository.findAllByMissionId(mission.getId())
+                .forEach(m -> board.get(m.getVerificationCount()).add(m.getMember()));
+        return board;
+    }
+
+    private Map<Integer, List<Member>> sortByVerifiedAt(final Map<Integer, List<Member>> groupedMembers) {
+        return groupedMembers.entrySet().stream()
+                .peek(entry -> entry.getValue().sort(Comparator.comparing(BaseEntity::getCreatedAt)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private List<MissionBoardResponse> convertToBoardResponse(final Map<Integer, List<Member>> groupedAndSortedMembers) {
+        return groupedAndSortedMembers.entrySet().stream()
+                .map(entry -> MissionBoardResponse.from(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private Map<Integer, List<Member>> initializeBoard(final Integer boardCount) {
+        return IntStream.range(0, boardCount + 1)
+                .boxed()
+                .collect(Collectors.toMap(i -> i, i -> new ArrayList<>()));
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
@@ -80,12 +80,17 @@ public class MissionVerificationService {
         if (isCompletedMission(mission, missionMember)) {
             throw new BadRequestException(ErrorCode.ALREADY_COMPLETED_MISSION);
         }
-        LocalDate today = LocalDate.now();
-        if (isDuplicatedVerification(memberId, mission.getId(), today)) {
+        if (isDuplicatedVerification(memberId, mission.getId())) {
             throw new BadRequestException(ErrorCode.DUPLICATE_VERIFICATION);
         }
-        if (!mission.isMissionDay(today)) {
+        if (!mission.isMissionPeriod()) {
+            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_PERIOD);
+        }
+        if (!mission.isMissionDay()) {
             throw new BadRequestException(ErrorCode.NOT_VERIFICATION_DAY);
+        }
+        if (!mission.isMissionTime()) {
+            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_TIME);
         }
     }
 
@@ -93,8 +98,8 @@ public class MissionVerificationService {
         return missionMember.getVerificationCount() >= mission.getBoardCount();
     }
 
-    private boolean isDuplicatedVerification(final Long memberId, final Long missionId, final LocalDate today) {
-        return missionVerificationRepository.findByMemberIdAndMissionIdAndDate(memberId, missionId, today).isPresent();
+    private boolean isDuplicatedVerification(final Long memberId, final Long missionId) {
+        return missionVerificationRepository.findByMemberIdAndMissionIdAndDate(memberId, missionId, LocalDate.now()).isPresent();
     }
 
     @Transactional

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/request/MissionBoardQuery.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/request/MissionBoardQuery.java
@@ -1,0 +1,6 @@
+package com.nexters.goalpanzi.application.mission.dto.request;
+
+public record MissionBoardQuery(
+        Long missionId
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardMemberResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardMemberResponse.java
@@ -1,0 +1,12 @@
+package com.nexters.goalpanzi.application.mission.dto.response;
+
+import com.nexters.goalpanzi.domain.member.CharacterType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MissionBoardMemberResponse(
+        @Schema(description = "닉네임", requiredMode = Schema.RequiredMode.REQUIRED)
+        String nickname,
+        @Schema(description = "캐릭터 타입", requiredMode = Schema.RequiredMode.REQUIRED)
+        CharacterType characterType
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
@@ -1,8 +1,7 @@
 package com.nexters.goalpanzi.application.mission.dto.response;
 
-import com.nexters.goalpanzi.application.member.dto.response.ProfileResponse;
 import com.nexters.goalpanzi.domain.member.Member;
-import com.nexters.goalpanzi.domain.mission.EventItem;
+import com.nexters.goalpanzi.domain.mission.Reward;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -11,17 +10,17 @@ import java.util.stream.Collectors;
 public record MissionBoardResponse(
         @Schema(description = "보드칸 번호", type = "integer", format = "int32", requiredMode = Schema.RequiredMode.REQUIRED)
         Integer number,
-        @Schema(description = "보드칸 이벤트", requiredMode = Schema.RequiredMode.REQUIRED)
-        String eventItem,
-        List<ProfileResponse> missionMembers
+        @Schema(description = "보드칸 보상", requiredMode = Schema.RequiredMode.REQUIRED)
+        Reward reward,
+        List<MissionBoardMemberResponse> missionBoardMembers
 ) {
 
-    public static MissionBoardResponse from(final Integer number, final List<Member> members) {
+    public static MissionBoardResponse of(final Integer number, final List<Member> members) {
         return new MissionBoardResponse(
                 number,
-                EventItem.of(number),
+                Reward.of(number),
                 members.stream().
-                        map(m -> new ProfileResponse(m.getNickname(), m.getCharacterType()))
+                        map(m -> new MissionBoardMemberResponse(m.getNickname(), m.getCharacterType()))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
@@ -1,0 +1,28 @@
+package com.nexters.goalpanzi.application.mission.dto.response;
+
+import com.nexters.goalpanzi.application.member.dto.response.ProfileResponse;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.mission.EventItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record MissionBoardResponse(
+        @Schema(description = "보드칸 번호", type = "integer", format = "int32", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer number,
+        @Schema(description = "보드칸 이벤트", requiredMode = Schema.RequiredMode.REQUIRED)
+        String eventItem,
+        List<ProfileResponse> missionMembers
+) {
+
+    public static MissionBoardResponse from(final Integer number, final List<Member> members) {
+        return new MissionBoardResponse(
+                number,
+                EventItem.of(number),
+                members.stream().
+                        map(m -> new ProfileResponse(m.getNickname(), m.getCharacterType()))
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardsResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardsResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.goalpanzi.application.mission.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MissionBoardsResponse(
+        @Schema(description = "미션 보드칸 정보 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<MissionBoardResponse> missionBoards
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionVerificationsResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionVerificationsResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.goalpanzi.application.mission.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MissionVerificationsResponse(
+        @Schema(description = "미션 인증 정보 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<MissionVerificationResponse> missionVerifications
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/EventItem.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/EventItem.java
@@ -16,7 +16,7 @@ public enum EventItem {
     BLACK_PIG(21),
     SUNRISE(25),
     GREEN_TEA_FIELD(29),
-    SEA(31);
+    BEACH(31);
 
     private final int number;
 

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/EventItem.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/EventItem.java
@@ -1,0 +1,39 @@
+package com.nexters.goalpanzi.domain.mission;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public enum EventItem {
+    ORANGE(1),
+    CANOLA_FLOWER(3),
+    DOLHARUBANG(6),
+    HORSE_RIDING(9),
+    HALLA_MOUNTAIN(13),
+    WATERFALL(17),
+    BLACK_PIG(21),
+    SUNRISE(25),
+    GREEN_TEA_FIELD(29),
+    SEA(31);
+
+    private final int number;
+
+    private static final Map<Integer, EventItem> EVENT_ITEM_MAP = new HashMap<>();
+
+    static {
+        for (EventItem item : values()) {
+            EVENT_ITEM_MAP.put(item.getNumber(), item);
+        }
+    }
+
+    EventItem(int number) {
+        this.number = number;
+    }
+
+    public static String of(final int number) {
+        EventItem item = EVENT_ITEM_MAP.get(number);
+        return (item != null) ? item.toString() : null;
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -1,12 +1,13 @@
 package com.nexters.goalpanzi.domain.mission;
 
-import com.nexters.goalpanzi.infrastructure.jpa.DaysOfWeekConverter;
 import com.nexters.goalpanzi.domain.common.BaseEntity;
+import com.nexters.goalpanzi.infrastructure.jpa.DaysOfWeekConverter;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import org.joda.time.LocalTime;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -108,7 +109,17 @@ public class Mission extends BaseEntity {
         }
     }
 
-    public boolean isMissionDay(final LocalDate date) {
-        return this.missionDays.contains(DayOfWeek.valueOf(date.getDayOfWeek().name()));
+    public boolean isMissionPeriod() {
+        LocalDate today = LocalDate.now();
+        return !today.isBefore(this.missionStartDate.toLocalDate()) && !today.isAfter(missionEndDate.toLocalDate());
+    }
+
+    public boolean isMissionDay() {
+        return this.missionDays.contains(DayOfWeek.valueOf(LocalDate.now().getDayOfWeek().name()));
+    }
+
+    public boolean isMissionTime() {
+        String now = LocalTime.now().toString().substring(0, 5);
+        return now.compareTo(uploadStartTime) >= 0 && now.compareTo(uploadEndTime) <= 0;
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Reward.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Reward.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Getter
-public enum EventItem {
+public enum Reward {
     ORANGE(1),
     CANOLA_FLOWER(3),
     DOLHARUBANG(6),
@@ -20,20 +20,19 @@ public enum EventItem {
 
     private final int number;
 
-    private static final Map<Integer, EventItem> EVENT_ITEM_MAP = new HashMap<>();
+    private static final Map<Integer, Reward> REWARD_MAP = new HashMap<>();
 
     static {
-        for (EventItem item : values()) {
-            EVENT_ITEM_MAP.put(item.getNumber(), item);
+        for (Reward item : values()) {
+            REWARD_MAP.put(item.getNumber(), item);
         }
     }
 
-    EventItem(int number) {
+    Reward(int number) {
         this.number = number;
     }
 
-    public static String of(final int number) {
-        EventItem item = EVENT_ITEM_MAP.get(number);
-        return (item != null) ? item.toString() : null;
+    public static Reward of(final int number) {
+        return REWARD_MAP.get(number);
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/exception/ErrorCode.java
+++ b/src/main/java/com/nexters/goalpanzi/exception/ErrorCode.java
@@ -34,7 +34,9 @@ public enum ErrorCode {
     NOT_FOUND_VERIFICATION("존재하지 않는 미션 인증입니다."),
     DUPLICATE_VERIFICATION("이미 인증한 미션이므로 더 이상 인증할 수 없습니다."),
     ALREADY_COMPLETED_MISSION("이미 완료된 미션이므로 더 이상 인증할 수 없습니다."),
+    NOT_VERIFICATION_PERIOD("인증 기간이 아니므로 인증할 수 없습니다."),
     NOT_VERIFICATION_DAY("인증 일자가 아니므로 인증할 수 없습니다."),
+    NOT_VERIFICATION_TIME("인증 시간대가 아니므로 인증할 수 없습니다."),
 
     // FILE UPLOAD
     INVALID_FILE("유효하지 않은 파일입니다."),

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardController.java
@@ -2,15 +2,13 @@ package com.nexters.goalpanzi.presentation.mission;
 
 import com.nexters.goalpanzi.application.mission.MissionBoardService;
 import com.nexters.goalpanzi.application.mission.dto.request.MissionBoardQuery;
-import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/missions")
@@ -20,10 +18,10 @@ public class MissionBoardController implements MissionBoardControllerDocs {
     private final MissionBoardService missionBoardService;
 
     @GetMapping("/{missionId}/board")
-    public ResponseEntity<List<MissionBoardResponse>> getBoard(
+    public ResponseEntity<MissionBoardsResponse> getBoard(
             @PathVariable(name = "missionId") final Long missionId
     ) {
-        List<MissionBoardResponse> response = missionBoardService.getBoard(new MissionBoardQuery(missionId));
+        MissionBoardsResponse response = missionBoardService.getBoard(new MissionBoardQuery(missionId));
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardController.java
@@ -1,0 +1,30 @@
+package com.nexters.goalpanzi.presentation.mission;
+
+import com.nexters.goalpanzi.application.mission.MissionBoardService;
+import com.nexters.goalpanzi.application.mission.dto.request.MissionBoardQuery;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/missions")
+@RestController
+public class MissionBoardController implements MissionBoardControllerDocs {
+
+    private final MissionBoardService missionBoardService;
+
+    @GetMapping("/{missionId}/board")
+    public ResponseEntity<List<MissionBoardResponse>> getBoard(
+            @PathVariable(name = "missionId") final Long missionId
+    ) {
+        List<MissionBoardResponse> response = missionBoardService.getBoard(new MissionBoardQuery(missionId));
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardControllerDocs.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardControllerDocs.java
@@ -1,6 +1,6 @@
 package com.nexters.goalpanzi.presentation.mission;
 
-import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,8 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-
-import java.util.List;
 
 @Tag(
         name = "미션 보드",
@@ -28,7 +26,7 @@ public interface MissionBoardControllerDocs {
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/{missionId}/board")
-    ResponseEntity<List<MissionBoardResponse>> getBoard(
+    ResponseEntity<MissionBoardsResponse> getBoard(
             @Schema(description = "미션 아이디", type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED)
             @PathVariable(name = "missionId") final Long missionId
     );

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardControllerDocs.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionBoardControllerDocs.java
@@ -1,0 +1,35 @@
+package com.nexters.goalpanzi.presentation.mission;
+
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(
+        name = "미션 보드",
+        description = """
+                미션 보드와 관련된 그룹입니다.
+                                
+                미션 보드판 정보을 제공합니다.
+                """
+)
+public interface MissionBoardControllerDocs {
+    @Operation(summary = "미션 보드판 조회", description = "해당 미션의 보드판 현황을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+    })
+    @GetMapping("/{missionId}/board")
+    ResponseEntity<List<MissionBoardResponse>> getBoard(
+            @Schema(description = "미션 아이디", type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED)
+            @PathVariable(name = "missionId") final Long missionId
+    );
+}

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionVerificationController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionVerificationController.java
@@ -5,6 +5,7 @@ import com.nexters.goalpanzi.application.mission.dto.request.CreateMissionVerifi
 import com.nexters.goalpanzi.application.mission.dto.request.MissionVerificationQuery;
 import com.nexters.goalpanzi.application.mission.dto.request.MyMissionVerificationQuery;
 import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationsResponse;
 import com.nexters.goalpanzi.common.argumentresolver.LoginMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/missions")
@@ -23,12 +23,12 @@ public class MissionVerificationController implements MissionVerificationControl
     private final MissionVerificationService missionVerificationService;
 
     @GetMapping("/{missionId}/verifications")
-    public ResponseEntity<List<MissionVerificationResponse>> getVerifications(
+    public ResponseEntity<MissionVerificationsResponse> getVerifications(
             @LoginMemberId final Long memberId,
             @PathVariable(name = "missionId") final Long missionId,
             @RequestParam(name = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate date
     ) {
-        List<MissionVerificationResponse> response = missionVerificationService.getVerifications(new MissionVerificationQuery(memberId, missionId, date));
+        MissionVerificationsResponse response = missionVerificationService.getVerifications(new MissionVerificationQuery(memberId, missionId, date));
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionVerificationControllerDocs.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/mission/MissionVerificationControllerDocs.java
@@ -1,6 +1,7 @@
 package com.nexters.goalpanzi.presentation.mission;
 
 import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationsResponse;
 import com.nexters.goalpanzi.common.argumentresolver.LoginMemberId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Tag(
         name = "미션 인증",
@@ -33,7 +33,7 @@ public interface MissionVerificationControllerDocs {
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/{missionId}/verifications")
-    ResponseEntity<List<MissionVerificationResponse>> getVerifications(
+    ResponseEntity<MissionVerificationsResponse> getVerifications(
             @Parameter(hidden = true) @LoginMemberId final Long memberId,
             @Schema(description = "미션 아이디", type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED)
             @PathVariable(name = "missionId") final Long missionId,

--- a/src/test/java/com/nexters/goalpanzi/acceptance/AcceptanceStep.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/AcceptanceStep.java
@@ -1,12 +1,6 @@
 package com.nexters.goalpanzi.acceptance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nexters.goalpanzi.application.auth.dto.request.GoogleLoginCommand;
-import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
-import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
 import com.nexters.goalpanzi.domain.mission.DayOfWeek;
 import com.nexters.goalpanzi.domain.mission.TimeOfDay;
 import com.nexters.goalpanzi.presentation.member.dto.UpdateProfileRequest;
@@ -110,8 +104,8 @@ public class AcceptanceStep {
         }
     }
 
-    public static List<MissionVerificationResponse> 일자별_미션_인증_조회(Long missionId, LocalDate date, String accessToken) throws JsonProcessingException {
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+    public static ExtractableResponse<Response> 일자별_미션_인증_조회(Long missionId, LocalDate date, String accessToken) {
+        return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, BEARER + accessToken)
                 .queryParam("date", date.toString())
@@ -119,10 +113,6 @@ public class AcceptanceStep {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        return objectMapper.readValue(response.asString(), new TypeReference<List<MissionVerificationResponse>>() {
-        });
     }
 
     public static ExtractableResponse<Response> 내_미션_인증_조회(Integer number, Long missionId, String accessToken) {
@@ -135,17 +125,13 @@ public class AcceptanceStep {
                 .extract();
     }
 
-    public static List<MissionBoardResponse> 보드판_조회(Long missionId, String accessToken) throws JsonProcessingException {
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+    public static ExtractableResponse<Response> 보드판_조회(Long missionId, String accessToken) {
+        return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, BEARER + accessToken)
                 .when().get("/api/missions/" + missionId + "/board")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        return objectMapper.readValue(response.asString(), new TypeReference<List<MissionBoardResponse>>() {
-        });
     }
 }

--- a/src/test/java/com/nexters/goalpanzi/acceptance/MissionBoardAcceptanceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/MissionBoardAcceptanceTest.java
@@ -1,9 +1,8 @@
 package com.nexters.goalpanzi.acceptance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nexters.goalpanzi.application.auth.dto.request.GoogleLoginCommand;
 import com.nexters.goalpanzi.application.auth.dto.response.LoginResponse;
-import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardsResponse;
 import com.nexters.goalpanzi.application.mission.dto.response.MissionDetailResponse;
 import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
 import com.nexters.goalpanzi.domain.mission.TimeOfDay;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static com.nexters.goalpanzi.acceptance.AcceptanceStep.*;
 import static com.nexters.goalpanzi.fixture.MemberFixture.*;
@@ -30,7 +28,7 @@ public class MissionBoardAcceptanceTest extends AcceptanceTest {
     private ObjectStorageClient objectStorageClient;
 
     @Test
-    void 보드판_정보를_조회한다() throws JsonProcessingException {
+    void 보드판_정보를_조회한다() {
         when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
 
         LoginResponse hostLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
@@ -48,18 +46,18 @@ public class MissionBoardAcceptanceTest extends AcceptanceTest {
         프로필_설정(new UpdateProfileRequest(NICKNAME_MEMBER_B, CHARACTER_MEMBER_B), memberBLogin.accessToken());
         미션_참여(mission.invitationCode(), memberBLogin.accessToken());
 
-        List<MissionBoardResponse> board = 보드판_조회(mission.missionId(), hostLogin.accessToken());
+        MissionBoardsResponse boards = 보드판_조회(mission.missionId(), hostLogin.accessToken()).as(MissionBoardsResponse.class);
 
         assertAll(
-                () -> assertThat(board.size()).isEqualTo(mission.boardCount() + 1),
-                () -> assertThat(board.get(0).eventItem()).isNull(),
-                () -> assertThat(board.get(0).number()).isEqualTo(0),
-                () -> assertThat(board.get(0).missionMembers().size()).isEqualTo(1),
-                () -> assertThat(board.get(1).eventItem()).isNotNull(),
-                () -> assertThat(board.get(1).number()).isEqualTo(1),
-                () -> assertThat(board.get(1).missionMembers().size()).isEqualTo(2),
-                () -> assertThat(board.get(1).missionMembers().get(0).nickname()).isEqualTo(NICKNAME_HOST),
-                () -> assertThat(board.get(1).missionMembers().get(1).nickname()).isEqualTo(NICKNAME_MEMBER_A)
+                () -> assertThat(boards.missionBoards().size()).isEqualTo(mission.boardCount() + 1),
+                () -> assertThat(boards.missionBoards().get(0).reward()).isNull(),
+                () -> assertThat(boards.missionBoards().get(0).number()).isEqualTo(0),
+                () -> assertThat(boards.missionBoards().get(0).missionBoardMembers().size()).isEqualTo(1),
+                () -> assertThat(boards.missionBoards().get(1).reward()).isNotNull(),
+                () -> assertThat(boards.missionBoards().get(1).number()).isEqualTo(1),
+                () -> assertThat(boards.missionBoards().get(1).missionBoardMembers().size()).isEqualTo(2),
+                () -> assertThat(boards.missionBoards().get(1).missionBoardMembers().get(0).nickname()).isEqualTo(NICKNAME_HOST),
+                () -> assertThat(boards.missionBoards().get(1).missionBoardMembers().get(1).nickname()).isEqualTo(NICKNAME_MEMBER_A)
         );
     }
 }

--- a/src/test/java/com/nexters/goalpanzi/acceptance/MissionBoardAcceptanceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/MissionBoardAcceptanceTest.java
@@ -1,0 +1,65 @@
+package com.nexters.goalpanzi.acceptance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.nexters.goalpanzi.application.auth.dto.request.GoogleLoginCommand;
+import com.nexters.goalpanzi.application.auth.dto.response.LoginResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionDetailResponse;
+import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
+import com.nexters.goalpanzi.domain.mission.TimeOfDay;
+import com.nexters.goalpanzi.presentation.member.dto.UpdateProfileRequest;
+import com.nexters.goalpanzi.presentation.mission.dto.CreateMissionRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.nexters.goalpanzi.acceptance.AcceptanceStep.*;
+import static com.nexters.goalpanzi.fixture.MemberFixture.*;
+import static com.nexters.goalpanzi.fixture.MissionFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class MissionBoardAcceptanceTest extends AcceptanceTest {
+
+    @MockBean
+    private ObjectStorageClient objectStorageClient;
+
+    @Test
+    void 보드판_정보를_조회한다() throws JsonProcessingException {
+        when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
+
+        LoginResponse hostLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+        CreateMissionRequest missionRequest = new CreateMissionRequest(DESCRIPTION, LocalDateTime.now(), LocalDateTime.now().plusDays(1), TimeOfDay.EVERYDAY, WEEK, 1);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_HOST, CHARACTER_HOST), hostLogin.accessToken());
+        MissionDetailResponse mission = 미션_생성(missionRequest, hostLogin.accessToken()).as(MissionDetailResponse.class);
+        미션_인증(IMAGE_FILE, mission.missionId(), hostLogin.accessToken());
+
+        LoginResponse memberALogin = 구글_로그인(new GoogleLoginCommand(EMAIL_MEMBER_A)).as(LoginResponse.class);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_MEMBER_A, CHARACTER_MEMBER_A), memberALogin.accessToken());
+        미션_참여(mission.invitationCode(), memberALogin.accessToken());
+        미션_인증(IMAGE_FILE, mission.missionId(), memberALogin.accessToken());
+
+        LoginResponse memberBLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_MEMBER_B)).as(LoginResponse.class);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_MEMBER_B, CHARACTER_MEMBER_B), memberBLogin.accessToken());
+        미션_참여(mission.invitationCode(), memberBLogin.accessToken());
+
+        List<MissionBoardResponse> board = 보드판_조회(mission.missionId(), hostLogin.accessToken());
+
+        assertAll(
+                () -> assertThat(board.size()).isEqualTo(mission.boardCount() + 1),
+                () -> assertThat(board.get(0).eventItem()).isNull(),
+                () -> assertThat(board.get(0).number()).isEqualTo(0),
+                () -> assertThat(board.get(0).missionMembers().size()).isEqualTo(1),
+                () -> assertThat(board.get(1).eventItem()).isNotNull(),
+                () -> assertThat(board.get(1).number()).isEqualTo(1),
+                () -> assertThat(board.get(1).missionMembers().size()).isEqualTo(2),
+                () -> assertThat(board.get(1).missionMembers().get(0).nickname()).isEqualTo(NICKNAME_HOST),
+                () -> assertThat(board.get(1).missionMembers().get(1).nickname()).isEqualTo(NICKNAME_MEMBER_A)
+        );
+    }
+}

--- a/src/test/java/com/nexters/goalpanzi/acceptance/MissionVerificationAcceptanceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/MissionVerificationAcceptanceTest.java
@@ -1,10 +1,10 @@
 package com.nexters.goalpanzi.acceptance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nexters.goalpanzi.application.auth.dto.request.GoogleLoginCommand;
 import com.nexters.goalpanzi.application.auth.dto.response.LoginResponse;
 import com.nexters.goalpanzi.application.mission.dto.response.MissionDetailResponse;
 import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationsResponse;
 import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
 import com.nexters.goalpanzi.domain.mission.DayOfWeek;
 import com.nexters.goalpanzi.domain.mission.TimeOfDay;
@@ -119,7 +119,7 @@ public class MissionVerificationAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 특정_일자의_미션_인증_현황을_조회한다() throws JsonProcessingException {
+    void 특정_일자의_미션_인증_현황을_조회한다() {
         when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
 
         LoginResponse hostLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
@@ -138,16 +138,16 @@ public class MissionVerificationAcceptanceTest extends AcceptanceTest {
         미션_참여(mission.invitationCode(), memberBLogin.accessToken());
         미션_인증(IMAGE_FILE, mission.missionId(), memberBLogin.accessToken());
 
-        List<MissionVerificationResponse> verifications = 일자별_미션_인증_조회(mission.missionId(), LocalDate.now(), hostLogin.accessToken());
+        MissionVerificationsResponse verifications = 일자별_미션_인증_조회(mission.missionId(), LocalDate.now(), hostLogin.accessToken()).as(MissionVerificationsResponse.class);
 
         assertAll(
-                () -> assertThat(verifications.size()).isEqualTo(3),
-                () -> assertThat(verifications.get(0).nickname()).isEqualTo(NICKNAME_HOST),
-                () -> assertThat(verifications.get(0).characterType()).isEqualTo(CHARACTER_HOST),
-                () -> assertThat(verifications.get(1).nickname()).isEqualTo(NICKNAME_MEMBER_B),
-                () -> assertThat(verifications.get(1).characterType()).isEqualTo(CHARACTER_MEMBER_B),
-                () -> assertThat(verifications.get(2).nickname()).isEqualTo(NICKNAME_MEMBER_A),
-                () -> assertThat(verifications.get(2).characterType()).isEqualTo(CHARACTER_MEMBER_A)
+                () -> assertThat(verifications.missionVerifications().size()).isEqualTo(3),
+                () -> assertThat(verifications.missionVerifications().get(0).nickname()).isEqualTo(NICKNAME_HOST),
+                () -> assertThat(verifications.missionVerifications().get(0).characterType()).isEqualTo(CHARACTER_HOST),
+                () -> assertThat(verifications.missionVerifications().get(1).nickname()).isEqualTo(NICKNAME_MEMBER_B),
+                () -> assertThat(verifications.missionVerifications().get(1).characterType()).isEqualTo(CHARACTER_MEMBER_B),
+                () -> assertThat(verifications.missionVerifications().get(2).nickname()).isEqualTo(NICKNAME_MEMBER_A),
+                () -> assertThat(verifications.missionVerifications().get(2).characterType()).isEqualTo(CHARACTER_MEMBER_A)
         );
     }
 

--- a/src/test/java/com/nexters/goalpanzi/acceptance/MissionVerificationAcceptanceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/MissionVerificationAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.nexters.goalpanzi.acceptance;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nexters.goalpanzi.application.auth.dto.request.GoogleLoginCommand;
 import com.nexters.goalpanzi.application.auth.dto.response.LoginResponse;
 import com.nexters.goalpanzi.application.mission.dto.response.MissionDetailResponse;
@@ -8,6 +9,7 @@ import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
 import com.nexters.goalpanzi.domain.mission.DayOfWeek;
 import com.nexters.goalpanzi.domain.mission.TimeOfDay;
 import com.nexters.goalpanzi.exception.ErrorCode;
+import com.nexters.goalpanzi.presentation.member.dto.UpdateProfileRequest;
 import com.nexters.goalpanzi.presentation.mission.dto.CreateMissionRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -20,7 +22,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.nexters.goalpanzi.acceptance.AcceptanceStep.*;
-import static com.nexters.goalpanzi.fixture.MemberFixture.EMAIL_HOST;
+import static com.nexters.goalpanzi.fixture.MemberFixture.*;
 import static com.nexters.goalpanzi.fixture.MissionFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -43,6 +45,23 @@ public class MissionVerificationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 미션_인증(IMAGE_FILE, mission.missionId(), login.accessToken());
 
         assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+
+    @Test
+    void 미션_기간이_아니므로_인증에_실패한다() {
+        when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
+
+        LoginResponse login = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+        CreateMissionRequest missionRequest = new CreateMissionRequest(DESCRIPTION, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), TimeOfDay.EVERYDAY, WEEK, 1);
+        MissionDetailResponse mission = 미션_생성(missionRequest, login.accessToken()).as(MissionDetailResponse.class);
+
+        ExtractableResponse<Response> response = 미션_인증(IMAGE_FILE, mission.missionId(), login.accessToken());
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(400),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo(ErrorCode.NOT_VERIFICATION_PERIOD.getMessage())
+        );
     }
 
     @Test
@@ -99,34 +118,46 @@ public class MissionVerificationAcceptanceTest extends AcceptanceTest {
         );
     }
 
-//    TODO 프로필 생성 후 확인 필요
-//    @Test
-//    void 특정_일자의_미션_인증_현황을_조회한다() {
-//        when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
-//
-//        LoginResponse login1 = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
-//
-//        CreateMissionRequest missionRequest = new CreateMissionRequest(DESCRIPTION, LocalDateTime.now(), LocalDateTime.now().plusDays(1), TimeOfDay.EVERYDAY, WEEK, 1);
-//        MissionDetailResponse mission = 미션_생성(missionRequest, login1.accessToken()).as(MissionDetailResponse.class);
-//        미션_참여(mission.invitationCode(), login1.accessToken());
-//        미션_인증(IMAGE_FILE, mission.missionId(), login1.accessToken());
-//
-//        LoginResponse login2 = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST2)).as(LoginResponse.class);
-//        미션_참여(mission.invitationCode(), login2.accessToken());
-//        미션_인증(IMAGE_FILE, mission.missionId(), login2.accessToken());
-//
-//        List<MissionVerificationResponse> verifications = 일자별_미션_인증_조회(mission.missionId(), LocalDate.now(), login1.accessToken()).as(List.class);
-//
-//        assertAll(
-//                () -> assertThat(verifications.size()).isEqualTo(2)
-//        );
-//    }
+    @Test
+    void 특정_일자의_미션_인증_현황을_조회한다() throws JsonProcessingException {
+        when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
+
+        LoginResponse hostLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+        CreateMissionRequest missionRequest = new CreateMissionRequest(DESCRIPTION, LocalDateTime.now(), LocalDateTime.now().plusDays(1), TimeOfDay.EVERYDAY, WEEK, 1);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_HOST, CHARACTER_HOST), hostLogin.accessToken());
+        MissionDetailResponse mission = 미션_생성(missionRequest, hostLogin.accessToken()).as(MissionDetailResponse.class);
+        미션_인증(IMAGE_FILE, mission.missionId(), hostLogin.accessToken());
+
+        LoginResponse memberALogin = 구글_로그인(new GoogleLoginCommand(EMAIL_MEMBER_A)).as(LoginResponse.class);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_MEMBER_A, CHARACTER_MEMBER_A), memberALogin.accessToken());
+        미션_참여(mission.invitationCode(), memberALogin.accessToken());
+        미션_인증(IMAGE_FILE, mission.missionId(), memberALogin.accessToken());
+
+        LoginResponse memberBLogin = 구글_로그인(new GoogleLoginCommand(EMAIL_MEMBER_B)).as(LoginResponse.class);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_MEMBER_B, CHARACTER_MEMBER_B), memberBLogin.accessToken());
+        미션_참여(mission.invitationCode(), memberBLogin.accessToken());
+        미션_인증(IMAGE_FILE, mission.missionId(), memberBLogin.accessToken());
+
+        List<MissionVerificationResponse> verifications = 일자별_미션_인증_조회(mission.missionId(), LocalDate.now(), hostLogin.accessToken());
+
+        assertAll(
+                () -> assertThat(verifications.size()).isEqualTo(3),
+                () -> assertThat(verifications.get(0).nickname()).isEqualTo(NICKNAME_HOST),
+                () -> assertThat(verifications.get(0).characterType()).isEqualTo(CHARACTER_HOST),
+                () -> assertThat(verifications.get(1).nickname()).isEqualTo(NICKNAME_MEMBER_B),
+                () -> assertThat(verifications.get(1).characterType()).isEqualTo(CHARACTER_MEMBER_B),
+                () -> assertThat(verifications.get(2).nickname()).isEqualTo(NICKNAME_MEMBER_A),
+                () -> assertThat(verifications.get(2).characterType()).isEqualTo(CHARACTER_MEMBER_A)
+        );
+    }
 
     @Test
     void 보드칸_번호에_해당하는_나의_미션_인증_내역을_조회한다() {
         when(objectStorageClient.uploadFile(any(MultipartFile.class))).thenReturn(UPLOADED_IMAGE_URL);
 
         LoginResponse login = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+        프로필_설정(new UpdateProfileRequest(NICKNAME_HOST, CHARACTER_HOST), login.accessToken());
+
         CreateMissionRequest missionRequest = new CreateMissionRequest(DESCRIPTION, LocalDateTime.now(), LocalDateTime.now().plusDays(1), TimeOfDay.EVERYDAY, WEEK, 1);
         MissionDetailResponse mission = 미션_생성(missionRequest, login.accessToken()).as(MissionDetailResponse.class);
         미션_인증(IMAGE_FILE, mission.missionId(), login.accessToken());
@@ -134,7 +165,8 @@ public class MissionVerificationAcceptanceTest extends AcceptanceTest {
         MissionVerificationResponse verification = 내_미션_인증_조회(1, mission.missionId(), login.accessToken()).as(MissionVerificationResponse.class);
 
         assertAll(
-                // TODO 추후 닉네임, 장기말 타입 검증도 추가
+                () -> assertThat(verification.nickname()).isEqualTo(NICKNAME_HOST),
+                () -> assertThat(verification.characterType()).isEqualTo(CHARACTER_HOST),
                 () -> assertThat(verification.imageUrl()).isEqualTo(UPLOADED_IMAGE_URL)
         );
     }

--- a/src/test/java/com/nexters/goalpanzi/domain/member/MemberTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/member/MemberTest.java
@@ -11,11 +11,11 @@ class MemberTest {
     @Test
     void 프로필_생성이_가능하다() {
         Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
-        member.updateProfile(NICKNAME, CharacterType.CAT);
+        member.updateProfile(NICKNAME_HOST, CharacterType.CAT);
 
         assertAll(
                 () -> assertThat(member.isProfileSet()).isTrue(),
-                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME),
+                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME_HOST),
                 () -> assertThat(member.getCharacterType()).isEqualTo(CharacterType.CAT)
         );
     }
@@ -23,12 +23,12 @@ class MemberTest {
     @Test
     void 프로필_생성후_변경이_가능하다() {
         Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
-        member.updateProfile(NICKNAME, CharacterType.CAT);
-        member.updateProfile(NICKNAME,null);
+        member.updateProfile(NICKNAME_HOST, CharacterType.CAT);
+        member.updateProfile(NICKNAME_HOST, null);
 
         assertAll(
                 () -> assertThat(member.isProfileSet()).isTrue(),
-                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME),
+                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME_HOST),
                 () -> assertThat(member.getCharacterType()).isEqualTo(CharacterType.CAT)
         );
     }
@@ -36,11 +36,11 @@ class MemberTest {
     @Test
     void 닉네임만_설정이_가능하다() {
         Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
-        member.updateProfile(NICKNAME, null);
+        member.updateProfile(NICKNAME_HOST, null);
 
         assertAll(
                 () -> assertThat(member.isProfileSet()).isFalse(),
-                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME)
+                () -> assertThat(member.getNickname()).isEqualTo(NICKNAME_HOST)
         );
     }
 

--- a/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
+++ b/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
@@ -1,11 +1,19 @@
 package com.nexters.goalpanzi.fixture;
 
+import com.nexters.goalpanzi.domain.member.CharacterType;
+
 public class MemberFixture {
     public static final Long MEMBER_ID = 1L;
     public static final String ID_TOKEN_HOST = "token_host";
     public static final String ID_TOKEN_MEMBER_A = "token_member_A";
     public static final String EMAIL_HOST = "host@gmail.com";
     public static final String EMAIL_MEMBER_A = "a@gmail.com";
+    public static final String EMAIL_MEMBER_B = "b@gmail.com";
     public static final String SOCIAL_ID = "12345";
-    public static final String NICKNAME = "song2";
+    public static final String NICKNAME_HOST = "goalpanzi";
+    public static final String NICKNAME_MEMBER_A = "song2";
+    public static final String NICKNAME_MEMBER_B = "kimyu0218";
+    public static final CharacterType CHARACTER_HOST = CharacterType.BEAR;
+    public static final CharacterType CHARACTER_MEMBER_A = CharacterType.BIRD;
+    public static final CharacterType CHARACTER_MEMBER_B = CharacterType.CAT;
 }


### PR DESCRIPTION
## Issue Number

close: #32 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
보드판 정보 API 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1. `보드판 개수 + 1` 크기의 배열 생성
2. `인증 횟수` 기준 그룹화
3. 그룹 내에서 `인증 시간` 오름차순으로 정렬

+) 인증 부분에서 빠진 유효성 검사 추가
- 미션 기간, 미션 시간 검증
- 기간은 테스트했는데 시간은 테스트 시점에 따라 pass/fail 여부가 결정될 것 같아 진행하지 않았습니다..!
- 

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
1차 mvp에서는 이벤트가 고정이라서 enum으로 선언했습니다. 구현하면서도 enum을 사용해도 되는지 확신이 없어서 더 좋은 의견 있으시면 편하게 말씀해주세요.. 🫠

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->

