### PR TITLE
fix: 미션 인증 조회 API 오류 수정

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
@@ -7,10 +7,11 @@ import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificatio
 import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationsResponse;
 import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
 import com.nexters.goalpanzi.domain.common.BaseEntity;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
 import com.nexters.goalpanzi.domain.mission.Mission;
 import com.nexters.goalpanzi.domain.mission.MissionMember;
 import com.nexters.goalpanzi.domain.mission.MissionVerification;
-import com.nexters.goalpanzi.domain.mission.MissionVerifications;
 import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
 import com.nexters.goalpanzi.exception.BadRequestException;
@@ -21,7 +22,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -30,6 +34,7 @@ public class MissionVerificationService {
 
     private final MissionVerificationRepository missionVerificationRepository;
     private final MissionMemberRepository missionMemberRepository;
+    private final MemberRepository memberRepository;
 
     private final ObjectStorageClient objectStorageClient;
 
@@ -39,12 +44,41 @@ public class MissionVerificationService {
         MissionVerificationQuery.SortType sortType = query.sortType() == null ? MissionVerificationQuery.SortType.VERIFIED_AT : query.sortType();
         Sort.Direction direction = query.direction() == null ? Sort.Direction.DESC : query.direction();
 
-        List<MissionMember> missionMembers = missionMemberRepository.findAllByMissionId(query.missionId());
-        MissionVerifications missionVerifications = new MissionVerifications(missionVerificationRepository.findAllByMissionIdAndDate(query.missionId(), date));
+        Member member = memberRepository.getMember(query.memberId());
 
-        return MissionVerificationsResponse.from(
-                missionVerifications.sortMissionVerifications(query.memberId(), sortType, direction, missionMembers)
-        );
+        List<MissionMember> missionMembers = missionMemberRepository.findAllByMissionId(query.missionId());
+        List<MissionVerification> verifications = missionVerificationRepository.findAllByMissionIdAndDate(query.missionId(), date);
+
+        Map<Long, MissionVerification> verificationMap = verifications.stream()
+                .collect(Collectors.toMap(v -> v.getMember().getId(), v -> v));
+
+        return new MissionVerificationsResponse(
+                missionMembers.stream()
+                        .map(m -> convertToVerificationResponse(m, verificationMap.get(m.getMember().getId())))
+                        .sorted(compareMissionVerificationResponses(member.getNickname(), sortType, direction))
+                        .collect(Collectors.toList()));
+    }
+
+    private MissionVerificationResponse convertToVerificationResponse(final MissionMember missionMember, final MissionVerification verification) {
+        return verification != null
+                ? MissionVerificationResponse.verified(missionMember.getMember(), verification)
+                : MissionVerificationResponse.notVerified(missionMember.getMember());
+    }
+
+    private static Comparator<MissionVerificationResponse> compareMissionVerificationResponses(final String nickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
+        return Comparator.comparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.nickname().equals(nickname)).reversed()
+                .thenComparing(compareMissionVerificationResponsesByOrder(sortType, direction));
+    }
+
+    private static Comparator<MissionVerificationResponse> compareMissionVerificationResponsesByOrder(final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
+        switch (sortType) {
+            case MissionVerificationQuery.SortType.VERIFIED_AT:
+            default:
+                if (direction.isAscending()) {
+                    return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.naturalOrder()));
+                }
+                return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.reverseOrder()));
+        }
     }
 
     public MissionVerificationResponse getMyVerification(final MyMissionVerificationQuery query) {

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/MissionVerifications.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/MissionVerifications.java
@@ -28,7 +28,7 @@ public class MissionVerifications {
     }
 
     private static Comparator<MissionVerification> compareMissionVerifications(final Long memberId, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
-        return Comparator.comparing((MissionVerification missionVerification) -> missionVerification.getId().equals(memberId)).reversed()
+        return Comparator.comparing((MissionVerification missionVerification) -> missionVerification.getMember().getId().equals(memberId)).reversed()
                 .thenComparing(compareMissionVerificationsByOrder(sortType, direction));
     }
 


### PR DESCRIPTION
## Issue Number

close: #49

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
`MissionVerificationResponse`에서 `MissionVerification`으로 변경하면서 빈 인증 내역에 대해 `null`을 넣어준 것이 원인 

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 일단 이전 서비스 코드 복원
- 복원 후 sort만 적용
 
## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
일단 이거 머지되고 나중에 코드 리팩토링 해볼게요 🥹
보드처럼 깔끔하게 만들고 싶었는데 보드랑 다르게 `null` 데이터가 있어서 이런 오류가 났나봐요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->