### PR TITLE
fix: 회원 탈퇴 후 재로그인시 가입 안되는 현상

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - fix/#55-member-login
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-      - feat/#11/-refactor-apple-login
+      - fix/#55-member-login
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/#55-member-login
 
 jobs:
   build-and-push:

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -14,8 +14,10 @@ import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -54,7 +56,10 @@ public class AuthService {
 
     private void checkDeletedMember(final String socialId) {
         memberRepository.findBySocialIdAndDeletedAtIsNotNull(socialId)
-                .ifPresent(memberRepository::delete);
+                .ifPresent( member -> {
+                    log.info("Deleting member with id {}", member.getId());
+                    memberRepository.delete(member);
+                });
     }
 
     public void logout(final Long memberId) {

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -59,10 +59,7 @@ public class AuthService {
 
     private void checkDeletedMember(final String socialId) {
         memberRepository.findBySocialIdAndDeletedAtIsNotNull(socialId)
-                .ifPresent(member -> {
-                    memberRepository.delete(member);
-                    log.info("Deleting member with id {}", member.getId());
-                });
+                .ifPresent(memberRepository::delete);
     }
 
     public void logout(final Long memberId) {

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -16,6 +16,7 @@ import com.nexters.goalpanzi.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -27,6 +28,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
 
+    @Transactional
     public LoginResponse appleOAuthLogin(final AppleLoginCommand command) {
         SocialUserProvider appleUserProvider = socialUserProviderFactory.getProvider(SocialType.APPLE);
         SocialUserInfo socialUserInfo = appleUserProvider.getSocialUserInfo(command.identityToken());
@@ -34,6 +36,7 @@ public class AuthService {
         return socialLogin(socialUserInfo, SocialType.APPLE);
     }
 
+    @Transactional
     public LoginResponse googleOAuthLogin(final GoogleLoginCommand command) {
         SocialUserInfo socialUserInfo = new SocialUserInfo(
                 GoogleIdentityToken.generate(command.email()), command.email());
@@ -56,8 +59,8 @@ public class AuthService {
 
     private void checkDeletedMember(final String socialId) {
         memberRepository.findBySocialIdAndDeletedAtIsNotNull(socialId)
-                .ifPresent( member -> {
-                    memberRepository.deleteById(member.getId());
+                .ifPresent(member -> {
+                    memberRepository.delete(member);
                     log.info("Deleting member with id {}", member.getId());
                 });
     }

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -57,8 +57,8 @@ public class AuthService {
     private void checkDeletedMember(final String socialId) {
         memberRepository.findBySocialIdAndDeletedAtIsNotNull(socialId)
                 .ifPresent( member -> {
+                    memberRepository.deleteById(member.getId());
                     log.info("Deleting member with id {}", member.getId());
-                    memberRepository.delete(member);
                 });
     }
 

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -46,7 +46,7 @@ public class AuthService {
 
     private LoginResponse socialLogin(final SocialUserInfo socialUserInfo, final SocialType socialType) {
         checkDeletedMember(socialUserInfo.socialId());
-        Member member = memberRepository.findBySocialId(socialUserInfo.socialId())
+        Member member = memberRepository.findBySocialIdAndDeletedAtIsNull(socialUserInfo.socialId())
                 .orElseGet(() ->
                         memberRepository.save(Member.socialLogin(socialUserInfo.socialId(), socialUserInfo.email(), socialType))
                 );

--- a/src/main/java/com/nexters/goalpanzi/application/member/MemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/member/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
     }
 
     private void validateNickname(final String nickname) {
-        memberRepository.findByNickname(nickname)
+        memberRepository.findByNicknameAndDeletedAtIsNull(nickname)
                 .ifPresent(member -> {
                     throw new AlreadyExistsException(ErrorCode.ALREADY_EXIST_NICKNAME, nickname);
                 });

--- a/src/main/java/com/nexters/goalpanzi/domain/member/Member.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/member/Member.java
@@ -12,12 +12,10 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 import java.util.Objects;
 
 @Entity
-@SQLRestriction("deleted_at is NULL")
 @Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/nexters/goalpanzi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/member/repository/MemberRepository.java
@@ -14,8 +14,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialIdAndDeletedAtIsNotNull(final String socialId);
 
+    Optional<Member> findByIdAndDeletedAtIsNull(Long memberId);
+
     default Member getMember(final Long memberId) {
-        return findById(memberId)
+        return findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, memberId));
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/member/repository/MemberRepository.java
@@ -4,16 +4,14 @@ import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findBySocialId(final String socialId);
+    Optional<Member> findBySocialIdAndDeletedAtIsNull(final String socialId);
 
-    Optional<Member> findByNickname(final String nickname);
+    Optional<Member> findByNicknameAndDeletedAtIsNull(final String nickname);
 
-    @Query(value = "select m.* from member m where m.social_id = :socialId and m.deleted_at is not null", nativeQuery = true)
     Optional<Member> findBySocialIdAndDeletedAtIsNotNull(final String socialId);
 
     default Member getMember(final Long memberId) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,6 +7,9 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
     show-sql: true
     open-in-view: false
   data:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,7 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
+    open-in-view: false
   data:
     redis:
       host: localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,10 +9,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
-    show-sql: true
+    show-sql: false
     open-in-view: false
 
   data:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    show-sql: false
+    show-sql: true
     open-in-view: false
 
   data:

--- a/src/main/resources/db/migration/V3__add_index.sql
+++ b/src/main/resources/db/migration/V3__add_index.sql
@@ -1,0 +1,15 @@
+create index idx_member__created_at on member (created_at);
+create index idx_member__updated_at on member (updated_at);
+create index idx_member__deleted_at on member (deleted_at);
+
+create index idx_mission_member__created_at on mission_member (created_at);
+create index idx_mission_member__updated_at on mission_member (updated_at);
+create index idx_mission_member__deleted_at on mission_member (deleted_at);
+
+create index idx_mission_verification__created_at on mission_verification (created_at);
+create index idx_mission_verification__updated_at on mission_verification (updated_at);
+create index idx_mission_verification__deleted_at on mission_verification (deleted_at);
+
+create index idx_mission__created_at on mission (created_at);
+create index idx_mission__updated_at on mission (updated_at);
+create index idx_mission__deleted_at on mission (deleted_at);


### PR DESCRIPTION
## Issue Number

close: #55 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
서비스에 트랜잭션이 안걸려있어서 영속성 컨텍스트로 관리가 되지 않아 회원 삭제시 한번 더 조회 후 삭제 하는데 이때 deletedAt restriction으로 삭제된 회원 필터링이 걸려 삭제가 안되던 문제
- 트랜잭션 어노테이션 추가
- deletedAt restriction 삭제 (회원의 경우 hard delete하는 경우가 있어 삭제하는게 추후 추적하기 편해보여요!)
- insert, update, delete timestamp 인덱스 추가

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
여기에 작성하세요

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
