### PR TITLE
refactor: jwt 환경 변수 일자로 관리

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/member/MemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/member/MemberService.java
@@ -3,6 +3,7 @@ package com.nexters.goalpanzi.application.member;
 import com.nexters.goalpanzi.application.member.dto.request.UpdateProfileCommand;
 import com.nexters.goalpanzi.application.member.dto.response.ProfileResponse;
 import com.nexters.goalpanzi.application.member.event.DeleteMemberEvent;
+import com.nexters.goalpanzi.domain.auth.repository.RefreshTokenRepository;
 import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
 import com.nexters.goalpanzi.exception.AlreadyExistsException;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
@@ -46,6 +48,7 @@ public class MemberService {
     @Transactional
     public void deleteMember(final Long memberId) {
         eventPublisher.publishEvent(new DeleteMemberEvent(memberId));
+        refreshTokenRepository.delete(memberId.toString());
         memberRepository.getMember(memberId).delete();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,9 +27,9 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token:
-    expires-in: 86400000
+    expires-in-days: 14 # TODO 추후 1로 변경
   refresh-token:
-    expires-in: 1209600000
+    expires-in-days: 14
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,9 +28,9 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token:
-    expires-in: 86400000
+    expires-in-days: 14 # TODO 추후 1로 변경
   refresh-token:
-    expires-in: 1209600000
+    expires-in-days: 14
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,9 +17,9 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token:
-    expires-in: 86400000
+    expires-in-days: 14 # TODO 추후 1로 변경
   refresh-token:
-    expires-in: 1209600000
+    expires-in-days: 14
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/nexters/goalpanzi/config/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/nexters/goalpanzi/config/jwt/JwtAuthenticationFilterTest.java
@@ -1,9 +1,9 @@
 package com.nexters.goalpanzi.config.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nexters.goalpanzi.common.filter.JwtAuthenticationFilter;
 import com.nexters.goalpanzi.common.auth.jwt.JwtParser;
 import com.nexters.goalpanzi.common.auth.jwt.JwtProvider;
+import com.nexters.goalpanzi.common.filter.JwtAuthenticationFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,8 +30,8 @@ public class JwtAuthenticationFilterTest {
         public JwtProvider jwtProvider() {
             return JwtProvider.builder()
                     .secret("secret")
-                    .accessExpiresIn(60000)
-                    .refreshExpiresIn(60000)
+                    .accessExpiresInDays(1)
+                    .refreshExpiresInDays(1)
                     .build();
         }
 

--- a/src/test/java/com/nexters/goalpanzi/config/jwt/JwtProviderTest.java
+++ b/src/test/java/com/nexters/goalpanzi/config/jwt/JwtProviderTest.java
@@ -22,14 +22,14 @@ public class JwtProviderTest {
     void JWT_토큰을_생성한다() {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(60000000)
-                .refreshExpiresIn(60000)
+                .accessExpiresInDays(1)
+                .refreshExpiresInDays(1)
                 .build();
 
         Jwt jwt = jwtProvider.generateTokens(MEMBER_ID.toString());
 
         System.out.println(jwt.accessToken());
-        
+
         assertThat(jwt).isNotNull();
     }
 
@@ -37,8 +37,8 @@ public class JwtProviderTest {
     void 유효한_JWT_토큰을_검증한다() {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(60000)
-                .refreshExpiresIn(60000)
+                .accessExpiresInDays(1)
+                .refreshExpiresInDays(1)
                 .build();
 
         Jwt jwt = jwtProvider.generateTokens(MEMBER_ID.toString());
@@ -55,8 +55,8 @@ public class JwtProviderTest {
     void 유효한_JWT_토큰에서_subject를_추출한다() {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(60000)
-                .refreshExpiresIn(60000)
+                .accessExpiresInDays(1)
+                .refreshExpiresInDays(1)
                 .build();
 
         Jwt jwt = jwtProvider.generateTokens(MEMBER_ID.toString());
@@ -73,12 +73,12 @@ public class JwtProviderTest {
     void 만료된_JWT_토큰을_검증한다() throws InterruptedException {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(1000)
-                .refreshExpiresIn(1000)
+                .accessExpiresInDays(0)
+                .refreshExpiresInDays(0)
                 .build();
 
         Jwt jwt = jwtProvider.generateTokens(MEMBER_ID.toString());
-        Thread.sleep(2000);
+
         Boolean isExpiredAccessToken = jwtProvider.validateToken(jwt.accessToken());
         Boolean isExpiredRefreshToken = jwtProvider.validateToken(jwt.refreshToken());
 
@@ -92,12 +92,12 @@ public class JwtProviderTest {
     void 만료된_JWT_토큰에서_subject를_추출한다() throws InterruptedException {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(1000)
-                .refreshExpiresIn(1000)
+                .accessExpiresInDays(0)
+                .refreshExpiresInDays(0)
                 .build();
 
         Jwt jwt = jwtProvider.generateTokens(MEMBER_ID.toString());
-        Thread.sleep(2000);
+
         String accessTokenSubject = jwtProvider.getSubject(jwt.accessToken());
         String refreshTokenSubject = jwtProvider.getSubject(jwt.refreshToken());
 
@@ -111,8 +111,8 @@ public class JwtProviderTest {
     void 서명이_잘못된_JWT_토큰을_검증한다() {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(60000)
-                .refreshExpiresIn(60000)
+                .accessExpiresInDays(1)
+                .refreshExpiresInDays(1)
                 .build();
 
         long currMillis = System.currentTimeMillis();
@@ -136,8 +136,8 @@ public class JwtProviderTest {
     void 잘못된_형식의_JWT_토큰을_검증한다() {
         JwtProvider jwtProvider = JwtProvider.builder()
                 .secret(SECRET)
-                .accessExpiresIn(60000)
-                .refreshExpiresIn(60000)
+                .accessExpiresInDays(1)
+                .refreshExpiresInDays(1)
                 .build();
 
         String malformedToken = "malformedToken";


### PR DESCRIPTION
## Issue Number

close: #4

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

+) access token도 14일로 늘렸습니다..!

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- jwt 환경 변수가 밀리초 단위라 유효 기간을 파악하기 어려움
- 밀리초 대신 일자를 저장하고 직접 계산하도록 수정

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
