### PR TITLE
fix: 파일 업로드 권한 및 Content-Type 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+  servlet:
+    multipart:
+      max-file-size: 5MB
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## Issue Number

close: #18

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

**버그 원인**
- 파일 업로드 시 `Access denied` 발생
- `Content-Type`도 파일 확장자가 아닌 `application/octet-stream`으로 설정됨

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- `withCannedAcl(CannedAccessControlList.PublicRead)`로 바꿔서 해결
- `ObjectMetadata`로 `Content-Type`을 설정하여 타입 유지

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
