### PR TITLE
refactor: 미션 인증 정렬/검증 로직 리팩토링

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -15,6 +15,8 @@ server {
     listen 443 ssl;
     server_name mission-mate.kro.kr;
 
+    client_max_body_size 5M;
+
     ssl_certificate /etc/letsencrypt/live/mission-mate.kro.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/mission-mate.kro.kr/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;

--- a/src/main/java/com/nexters/goalpanzi/application/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/apple/AppleClaimsValidator.java
@@ -23,7 +23,7 @@ public class AppleClaimsValidator {
 
     public boolean isValid(final Claims claims) {
         return claims.getIssuer().contains(iss) &&
-                claims.getAudience().equals(clientId) &&
-                Nonce.isValid(claims.get(NONCE_KEY, String.class));
+                claims.getAudience().equals(clientId);
+//                Nonce.isValid(claims.get(NONCE_KEY, String.class));
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
@@ -36,8 +36,7 @@ public class MissionBoardService {
         Member member = memberRepository.getMember(query.memberId());
         Mission mission = missionRepository.getMission(query.missionId());
         MissionMembers missionMembers = getMissionMembers(query.missionId(), query.sortType(), query.direction());
-//        TODO 추후 활성화
-//        missionMembers.verifyMissionMember(member);
+        missionMembers.verifyMissionMember(member);
 
         Map<Integer, List<Member>> boardMap = groupByVerificationCount(mission, missionMembers);
         List<MissionBoardResponse> boards = new ArrayList<>();

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -36,7 +36,7 @@ public class MissionVerificationResponseSorter {
         missionMembers.forEach(missionMember -> {
             Member member = missionMember.getMember();
             Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member.getId()));
-            MissionVerificationResponse response = createResponse(member, verification);
+            MissionVerificationResponse response = createResponseForMissionMember(member, verification);
             responses.add(response);
         });
 
@@ -44,13 +44,12 @@ public class MissionVerificationResponseSorter {
         return responses;
     }
 
-    private MissionVerificationResponse createResponse(final Member member, final Optional<MissionVerification> optionalMissionVerification) {
-        return optionalMissionVerification
-                .map(missionVerification -> {
-                    MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.getId(), member.getId());
-                    return MissionVerificationResponse.of(member, Optional.of(missionVerification), Optional.ofNullable(missionVerificationView));
-                })
-                .orElseGet(() -> MissionVerificationResponse.of(member, Optional.empty(), Optional.empty()));
+    private MissionVerificationResponse createResponseForMissionMember(final Member member, final Optional<MissionVerification> missionVerification) {
+        if (missionVerification.isEmpty()) {
+            return MissionVerificationResponse.of(member, Optional.empty(), Optional.empty());
+        }
+        MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.get().getId(), member.getId());
+        return MissionVerificationResponse.of(member, missionVerification, Optional.ofNullable(missionVerificationView));
     }
 
     private Comparator<MissionVerificationResponse> compareResponses(final String myNickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -1,0 +1,80 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.application.mission.dto.request.MissionVerificationQuery;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.MissionVerification;
+import com.nexters.goalpanzi.domain.mission.MissionVerificationView;
+import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class MissionVerificationResponseSorter {
+
+    private final MissionVerificationViewRepository missionVerificationViewRepository;
+
+    public List<MissionVerificationResponse> sort(
+            final Member member,
+            final MissionVerificationQuery.SortType sortType,
+            final Sort.Direction direction,
+            final List<MissionVerification> missionVerifications,
+            final List<MissionMember> missionMembers
+    ) {
+        List<MissionVerificationResponse> responses = new ArrayList<>();
+        Map<Long, MissionVerification> verifications = missionVerifications.stream()
+                .collect(Collectors.toMap(
+                        missionVerification -> missionVerification.getMember().getId(),
+                        missionVerification -> missionVerification));
+
+        missionMembers.forEach(missionMember -> {
+            Member member1 = missionMember.getMember();
+            Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member1.getId()));
+            MissionVerificationResponse response = createResponse(member1, verification);
+            responses.add(response);
+        });
+
+        responses.sort(compareResponses(member.getNickname(), sortType, direction));
+        return responses;
+    }
+
+    private MissionVerificationResponse createResponse(final Member member, final Optional<MissionVerification> optionalMissionVerification) {
+        return optionalMissionVerification
+                .map(missionVerification -> {
+                    MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.getId(), member.getId());
+                    return MissionVerificationResponse.of(member, Optional.of(missionVerification), Optional.ofNullable(missionVerificationView));
+                })
+                .orElseGet(() -> MissionVerificationResponse.of(member, Optional.empty(), Optional.empty()));
+    }
+
+    private Comparator<MissionVerificationResponse> compareResponses(final String nickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
+        return myVerificationFirst(nickname)
+                .thenComparing(unviewedVerificationFirst())
+                .thenComparing(compareResponsesByOrder(sortType, direction));
+    }
+
+    private Comparator<MissionVerificationResponse> myVerificationFirst(final String nickname) {
+        return Comparator.comparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.nickname().equals(nickname)).reversed();
+    }
+
+    private Comparator<MissionVerificationResponse> unviewedVerificationFirst() {
+        return Comparator.comparing(MissionVerificationResponse::viewedAt, Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+    private Comparator<MissionVerificationResponse> compareResponsesByOrder(final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
+        switch (sortType) {
+            case MissionVerificationQuery.SortType.VERIFIED_AT:
+            default:
+                if (direction.isAscending()) {
+                    return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.naturalOrder()));
+                }
+                return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.reverseOrder()));
+        }
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -36,7 +36,7 @@ public class MissionVerificationResponseSorter {
         missionMembers.forEach(missionMember -> {
             Member member = missionMember.getMember();
             Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member.getId()));
-            MissionVerificationResponse response = createResponseOfMissionMember(member, verification);
+            MissionVerificationResponse response = createResponseOfMissionMember(member, me, verification);
             responses.add(response);
         });
 
@@ -44,11 +44,11 @@ public class MissionVerificationResponseSorter {
         return responses;
     }
 
-    private MissionVerificationResponse createResponseOfMissionMember(final Member member, final Optional<MissionVerification> missionVerification) {
+    private MissionVerificationResponse createResponseOfMissionMember(final Member member, final Member viewer, final Optional<MissionVerification> missionVerification) {
         if (missionVerification.isEmpty()) {
             return MissionVerificationResponse.of(member, Optional.empty(), Optional.empty());
         }
-        MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.get().getId(), member.getId());
+        MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.get().getId(), viewer.getId());
         return MissionVerificationResponse.of(member, missionVerification, Optional.ofNullable(missionVerificationView));
     }
 

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -21,7 +21,7 @@ public class MissionVerificationResponseSorter {
     private final MissionVerificationViewRepository missionVerificationViewRepository;
 
     public List<MissionVerificationResponse> sort(
-            final Member member,
+            final Member me,
             final MissionVerificationQuery.SortType sortType,
             final Sort.Direction direction,
             final List<MissionVerification> missionVerifications,
@@ -34,13 +34,13 @@ public class MissionVerificationResponseSorter {
                         missionVerification -> missionVerification));
 
         missionMembers.forEach(missionMember -> {
-            Member member1 = missionMember.getMember();
-            Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member1.getId()));
-            MissionVerificationResponse response = createResponse(member1, verification);
+            Member member = missionMember.getMember();
+            Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member.getId()));
+            MissionVerificationResponse response = createResponse(member, verification);
             responses.add(response);
         });
 
-        responses.sort(compareResponses(member.getNickname(), sortType, direction));
+        responses.sort(compareResponses(me.getNickname(), sortType, direction));
         return responses;
     }
 
@@ -53,14 +53,14 @@ public class MissionVerificationResponseSorter {
                 .orElseGet(() -> MissionVerificationResponse.of(member, Optional.empty(), Optional.empty()));
     }
 
-    private Comparator<MissionVerificationResponse> compareResponses(final String nickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
-        return myVerificationFirst(nickname)
+    private Comparator<MissionVerificationResponse> compareResponses(final String myNickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
+        return myVerificationFirst(myNickname)
                 .thenComparing(unviewedVerificationFirst())
                 .thenComparing(compareResponsesByOrder(sortType, direction));
     }
 
-    private Comparator<MissionVerificationResponse> myVerificationFirst(final String nickname) {
-        return Comparator.comparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.nickname().equals(nickname)).reversed();
+    private Comparator<MissionVerificationResponse> myVerificationFirst(final String myNickname) {
+        return Comparator.comparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.nickname().equals(myNickname)).reversed();
     }
 
     private Comparator<MissionVerificationResponse> unviewedVerificationFirst() {

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -36,7 +36,7 @@ public class MissionVerificationResponseSorter {
         missionMembers.forEach(missionMember -> {
             Member member = missionMember.getMember();
             Optional<MissionVerification> verification = Optional.ofNullable(verifications.get(member.getId()));
-            MissionVerificationResponse response = createResponseForMissionMember(member, verification);
+            MissionVerificationResponse response = createResponseOfMissionMember(member, verification);
             responses.add(response);
         });
 
@@ -44,7 +44,7 @@ public class MissionVerificationResponseSorter {
         return responses;
     }
 
-    private MissionVerificationResponse createResponseForMissionMember(final Member member, final Optional<MissionVerification> missionVerification) {
+    private MissionVerificationResponse createResponseOfMissionMember(final Member member, final Optional<MissionVerification> missionVerification) {
         if (missionVerification.isEmpty()) {
             return MissionVerificationResponse.of(member, Optional.empty(), Optional.empty());
         }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
@@ -37,7 +37,7 @@ public class MissionVerificationService {
     private final MemberRepository memberRepository;
 
     private final ObjectStorageClient objectStorageClient;
-    
+
     private final MissionVerificationValidator missionVerificationValidator;
     private final MissionVerificationResponseSorter missionVerificationResponseSorter;
 
@@ -62,7 +62,7 @@ public class MissionVerificationService {
     public void createVerification(final CreateMissionVerificationCommand command) {
         MissionMember missionMember = missionMemberRepository.getMissionMember(command.memberId(), command.missionId());
 
-        missionVerificationValidator.validateVerificationSubmission(missionMember);
+        missionVerificationValidator.validate(missionMember);
 
         String imageUrl = objectStorageClient.uploadFile(command.imageFile());
         missionMember.verify();

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
@@ -10,21 +10,21 @@ import com.nexters.goalpanzi.application.upload.ObjectStorageClient;
 import com.nexters.goalpanzi.domain.common.BaseEntity;
 import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
-import com.nexters.goalpanzi.domain.mission.*;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.MissionMembers;
+import com.nexters.goalpanzi.domain.mission.MissionVerification;
+import com.nexters.goalpanzi.domain.mission.MissionVerificationView;
 import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationViewRepository;
-import com.nexters.goalpanzi.exception.BadRequestException;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -37,8 +37,10 @@ public class MissionVerificationService {
     private final MemberRepository memberRepository;
 
     private final ObjectStorageClient objectStorageClient;
+    
+    private final MissionVerificationValidator missionVerificationValidator;
+    private final MissionVerificationResponseSorter missionVerificationResponseSorter;
 
-    @Transactional(readOnly = true)
     public MissionVerificationsResponse getVerifications(final MissionVerificationQuery query) {
         LocalDate date = query.date() == null ? LocalDate.now() : query.date();
 
@@ -47,46 +49,7 @@ public class MissionVerificationService {
         missionMembers.verifyMissionMember(member);
         List<MissionVerification> missionVerifications = missionVerificationRepository.findAllByMissionIdAndDate(query.missionId(), date);
 
-        return new MissionVerificationsResponse(sortMissionVerifications(member, query.sortType(), query.direction(), missionVerifications, missionMembers.getMissionMembers()));
-    }
-
-    private List<MissionVerificationResponse> sortMissionVerifications(final Member member, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction, final List<MissionVerification> missionVerifications, final List<MissionMember> missionMembers) {
-        List<MissionVerificationResponse> response = new ArrayList<>();
-        Map<Long, MissionVerification> map = missionVerifications.stream()
-                .collect(Collectors.toMap(missionVerification -> missionVerification.getMember().getId(), missionVerification -> missionVerification));
-
-        missionMembers.forEach(missionMember -> {
-            Member member1 = missionMember.getMember();
-            MissionVerification missionVerification = map.get(member1.getId());
-            if (missionVerification == null) {
-                MissionVerificationResponse missionVerificationResponse = MissionVerificationResponse.of(member1, Optional.empty(), Optional.empty());
-                response.add(missionVerificationResponse);
-            } else {
-                MissionVerificationView missionVerificationView = missionVerificationViewRepository.getMissionVerificationView(missionVerification.getId(), member1.getId());
-                MissionVerificationResponse missionVerificationResponse = MissionVerificationResponse.of(member1, Optional.of(missionVerification), Optional.ofNullable(missionVerificationView));
-                response.add(missionVerificationResponse);
-            }
-        });
-
-        response.sort(compareMissionVerificationResponses(member.getNickname(), sortType, direction));
-        return response;
-    }
-
-    private static Comparator<MissionVerificationResponse> compareMissionVerificationResponses(final String nickname, final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
-        return Comparator.comparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.nickname().equals(nickname)).reversed()
-                .thenComparing((MissionVerificationResponse missionVerificationResponse) -> missionVerificationResponse.viewedAt() == null, Comparator.reverseOrder())
-                .thenComparing(compareMissionVerificationResponsesByOrder(sortType, direction));
-    }
-
-    private static Comparator<MissionVerificationResponse> compareMissionVerificationResponsesByOrder(final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {
-        switch (sortType) {
-            case MissionVerificationQuery.SortType.VERIFIED_AT:
-            default:
-                if (direction.isAscending()) {
-                    return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.naturalOrder()));
-                }
-                return Comparator.comparing(MissionVerificationResponse::verifiedAt, Comparator.nullsLast(Comparator.reverseOrder()));
-        }
+        return new MissionVerificationsResponse(missionVerificationResponseSorter.sort(member, query.sortType(), query.direction(), missionVerifications, missionMembers.getMissionMembers()));
     }
 
     public MissionVerificationResponse getMyVerification(final MyMissionVerificationQuery query) {
@@ -98,39 +61,12 @@ public class MissionVerificationService {
     @Transactional
     public void createVerification(final CreateMissionVerificationCommand command) {
         MissionMember missionMember = missionMemberRepository.getMissionMember(command.memberId(), command.missionId());
-        Mission mission = missionMember.getMission();
 
-        checkVerificationValidation(command.memberId(), mission, missionMember.getVerificationCount());
+        missionVerificationValidator.validateVerificationSubmission(missionMember);
 
         String imageUrl = objectStorageClient.uploadFile(command.imageFile());
         missionMember.verify();
-        missionVerificationRepository.save(new MissionVerification(missionMember.getMember(), mission, imageUrl, missionMember.getVerificationCount()));
-    }
-
-    private void checkVerificationValidation(final Long memberId, final Mission mission, final Integer verificationCount) {
-        if (isCompletedMission(mission, verificationCount)) {
-            throw new BadRequestException(ErrorCode.ALREADY_COMPLETED_MISSION);
-        }
-        if (isDuplicatedVerification(memberId, mission.getId())) {
-            throw new BadRequestException(ErrorCode.DUPLICATE_VERIFICATION);
-        }
-        if (!mission.isMissionPeriod()) {
-            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_PERIOD);
-        }
-        if (!mission.isMissionDay()) {
-            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_DAY);
-        }
-        if (!mission.isMissionTime()) {
-            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_TIME);
-        }
-    }
-
-    private boolean isCompletedMission(final Mission mission, final Integer verificationCount) {
-        return verificationCount >= mission.getBoardCount();
-    }
-
-    private boolean isDuplicatedVerification(final Long memberId, final Long missionId) {
-        return missionVerificationRepository.findByMemberIdAndMissionIdAndDate(memberId, missionId, LocalDate.now()).isPresent();
+        missionVerificationRepository.save(new MissionVerification(missionMember.getMember(), missionMember.getMission(), imageUrl, missionMember.getVerificationCount()));
     }
 
     @Transactional

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidator.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidator.java
@@ -16,7 +16,7 @@ public class MissionVerificationValidator {
 
     private final MissionVerificationRepository missionVerificationRepository;
 
-    public void validateVerificationSubmission(final MissionMember missionMember) {
+    public void validate(final MissionMember missionMember) {
         Mission mission = missionMember.getMission();
 
         validateCompletion(mission, missionMember);

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidator.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidator.java
@@ -1,0 +1,58 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.domain.mission.Mission;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
+import com.nexters.goalpanzi.exception.BadRequestException;
+import com.nexters.goalpanzi.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@Component
+public class MissionVerificationValidator {
+
+    private final MissionVerificationRepository missionVerificationRepository;
+
+    public void validateVerificationSubmission(final MissionMember missionMember) {
+        Mission mission = missionMember.getMission();
+
+        validateCompletion(mission, missionMember);
+        validateDuplication(mission, missionMember);
+        validateTime(mission);
+    }
+
+    private void validateCompletion(final Mission mission, final MissionMember missionMember) {
+        if (isCompletedMission(mission, missionMember)) {
+            throw new BadRequestException(ErrorCode.ALREADY_COMPLETED_MISSION);
+        }
+    }
+
+    private boolean isCompletedMission(final Mission mission, final MissionMember missionMember) {
+        return missionMember.getVerificationCount() >= mission.getBoardCount();
+    }
+
+    private void validateDuplication(final Mission mission, final MissionMember missionMember) {
+        if (isDuplicatedVerification(missionMember.getId(), mission.getId())) {
+            throw new BadRequestException(ErrorCode.DUPLICATE_VERIFICATION);
+        }
+    }
+
+    private boolean isDuplicatedVerification(final Long memberId, final Long missionId) {
+        return missionVerificationRepository.findByMemberIdAndMissionIdAndDate(memberId, missionId, LocalDate.now()).isPresent();
+    }
+
+    private void validateTime(final Mission mission) {
+        if (!mission.isMissionPeriod()) {
+            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_PERIOD);
+        }
+        if (!mission.isMissionDay()) {
+            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_DAY);
+        }
+        if (!mission.isMissionTime()) {
+            throw new BadRequestException(ErrorCode.NOT_VERIFICATION_TIME);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,8 +5,8 @@
               value="%d{yyyy-MM-dd HH:mm:ss} %green([%thread]) %highlight(%5level) %yellow(%logger{36}) - %msg%n"/>
     <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %5level %logger{36} - %msg%n"/>
     <property name="LOG_PATH" value="./logs"/>
-    <property name="FILE_NAME" value="api-server.log"/>
-    <property name="FILE_NAME_PATTERN" value="api-server.{yyyy-MM-dd}.%d.log"/>
+    <property name="FILE_NAME" value="${LOG_PATH}/api-server.log"/>
+    <property name="FILE_NAME_PATTERN" value="${LOG_PATH}/api-server.{yyyy-MM-dd}.%d.log"/>
     <property name="MAX_HISTORY" value="3"/>
     <property name="MAX_SIZE" value="5KB"/>
     <property name="TOTAL_SIZE_CAP" value="10MB"/>

--- a/src/test/java/com/nexters/goalpanzi/application/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/auth/apple/AppleClaimsValidatorTest.java
@@ -27,15 +27,15 @@ class AppleClaimsValidatorTest {
         assertThat(appleClaimsValidator.isValid(claims)).isTrue();
     }
 
-    @Test
-    void Nonce_값이_잘못된_경우_검증에_실패한다() {
-        Map<String, Object> claimsMap = new HashMap<>();
-        claimsMap.put(NONCE_KEY, "abcde");
-
-        Claims claims = Jwts.claims(claimsMap)
-                .setIssuer("iss")
-                .setAudience("aud");
-
-        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
-    }
+//    @Test
+//    void Nonce_값이_잘못된_경우_검증에_실패한다() {
+//        Map<String, Object> claimsMap = new HashMap<>();
+//        claimsMap.put(NONCE_KEY, "abcde");
+//
+//        Claims claims = Jwts.claims(claimsMap)
+//                .setIssuer("iss")
+//                .setAudience("aud");
+//
+//        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+//    }
 }

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionBoardServiceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionBoardServiceTest.java
@@ -1,0 +1,97 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.application.mission.dto.request.MissionBoardQuery;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionBoardsResponse;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
+import com.nexters.goalpanzi.domain.mission.Mission;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
+import com.nexters.goalpanzi.domain.mission.repository.MissionRepository;
+import com.nexters.goalpanzi.fixture.MissionFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class MissionBoardServiceTest {
+
+    Member me;
+    List<Member> members;
+
+    @MockBean
+    MissionRepository missionRepository;
+
+    @MockBean
+    MissionMemberRepository missionMemberRepository;
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @Autowired
+    MissionBoardService missionBoardService;
+
+    @BeforeEach
+    void setUp() {
+        me = mock(Member.class);
+        when(me.getId()).thenReturn(1L);
+
+        Member member1 = mock(Member.class);
+        when(member1.getId()).thenReturn(2L);
+
+        Member member2 = mock(Member.class);
+        when(member2.getId()).thenReturn(3L);
+
+        members = List.of(me, member1, member2);
+    }
+
+    @Test
+    void 보드판_정보를_조회한다() {
+        Mission mission = MissionFixture.create();
+        MissionMember missionMember1 = mock(MissionMember.class);
+        MissionMember missionMember2 = mock(MissionMember.class);
+        MissionMember missionMember3 = mock(MissionMember.class);
+        MissionBoardQuery query = new MissionBoardQuery(me.getId(), 1L, MissionBoardQuery.SortType.RANK, Sort.Direction.ASC);
+
+        LocalDateTime now = LocalDateTime.now();
+        when(missionMember1.getUpdatedAt()).thenReturn(now);
+        when(missionMember1.getVerificationCount()).thenReturn(1);
+        when(missionMember1.getMember()).thenReturn(members.get(0));
+
+        when(missionMember2.getUpdatedAt()).thenReturn(now);
+        when(missionMember2.getVerificationCount()).thenReturn(1);
+        when(missionMember2.getMember()).thenReturn(members.get(1));
+
+        when(missionMember3.getUpdatedAt()).thenReturn(now);
+        when(missionMember3.getVerificationCount()).thenReturn(2);
+        when(missionMember3.getMember()).thenReturn(members.get(2));
+
+        when(memberRepository.getMember(me.getId())).thenReturn(me);
+        when(missionRepository.getMission(anyLong())).thenReturn(mission);
+        when(missionMemberRepository.findAllByMissionId(anyLong(), any())).thenReturn(List.of(missionMember1, missionMember2, missionMember3));
+
+        MissionBoardsResponse response = missionBoardService.getBoard(query);
+        assertAll(
+                () -> assertThat(response.missionBoards().size()).isEqualTo(mission.getBoardCount() + 1),
+                () -> assertThat(response.rank()).isEqualTo(2),
+                () -> assertThat(response.progressCount()).isEqualTo(3),
+
+                () -> assertThat(response.missionBoards().get(1).isMyPosition()).isTrue(),
+                () -> assertThat(response.missionBoards().get(1).missionBoardMembers().size()).isEqualTo(2),
+                () -> assertThat(response.missionBoards().get(2).missionBoardMembers().size()).isEqualTo(1)
+        );
+    }
+}

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionBoardServiceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionBoardServiceTest.java
@@ -80,7 +80,9 @@ class MissionBoardServiceTest {
         when(missionMember3.getMember()).thenReturn(members.get(2));
 
         when(memberRepository.getMember(me.getId())).thenReturn(me);
+
         when(missionRepository.getMission(anyLong())).thenReturn(mission);
+
         when(missionMemberRepository.findAllByMissionId(anyLong(), any())).thenReturn(List.of(missionMember1, missionMember2, missionMember3));
 
         MissionBoardsResponse response = missionBoardService.getBoard(query);

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorterTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorterTest.java
@@ -1,0 +1,207 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.application.mission.dto.request.MissionVerificationQuery;
+import com.nexters.goalpanzi.application.mission.dto.response.MissionVerificationResponse;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.mission.Mission;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.MissionVerification;
+import com.nexters.goalpanzi.domain.mission.MissionVerificationView;
+import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationViewRepository;
+import com.nexters.goalpanzi.fixture.MissionFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.nexters.goalpanzi.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class MissionVerificationResponseSorterTest {
+
+    Member me;
+    List<MissionMember> missionMembers;
+
+    @MockBean
+    MissionVerificationViewRepository missionVerificationViewRepository;
+
+    @Autowired
+    MissionVerificationResponseSorter missionVerificationResponseSorter;
+
+    @BeforeEach
+    void setUp() {
+        me = mock(Member.class);
+        when(me.getNickname()).thenReturn(NICKNAME_HOST);
+        when(me.getId()).thenReturn(1L);
+
+        Member memberA = mock(Member.class);
+        when(memberA.getNickname()).thenReturn(NICKNAME_MEMBER_A);
+        when(memberA.getId()).thenReturn(2L);
+
+        Member memberB = mock(Member.class);
+        when(memberB.getNickname()).thenReturn(NICKNAME_MEMBER_B);
+        when(memberB.getId()).thenReturn(3L);
+
+        Mission mission = MissionFixture.create();
+        missionMembers = List.of(
+                new MissionMember(me, mission, 0),
+                new MissionMember(memberA, mission, 0),
+                new MissionMember(memberB, mission, 0)
+        );
+    }
+
+    @Test
+    void 미션_인증_현황의_개수는_항상_미션에_참여한_멤버의_수와_일치한다() {
+        List<MissionVerification> missionVerifications = List.of();
+
+        when(missionVerificationViewRepository.getMissionVerificationView(any(), any())).thenReturn(null);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.ASC, missionVerifications, missionMembers);
+        assertThat(responses.size()).isEqualTo(missionMembers.size());
+    }
+
+    @Test
+    void 나의_미션_인증_현황은_항상_0번째에_온다() {
+        MissionVerification missionVerificationOfMe = mock(MissionVerification.class);
+        List<MissionVerification> missionVerifications = List.of(missionVerificationOfMe);
+
+        when(missionVerificationOfMe.getMember()).thenReturn(me);
+        when(missionVerificationOfMe.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(missionVerificationViewRepository.getMissionVerificationView(any(), any())).thenReturn(null);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.DESC, missionVerifications, missionMembers);
+        assertThat(responses.getFirst().nickname()).isEqualTo(me.getNickname());
+    }
+
+    @Test
+    void 미션_인증을_하지_않은_멤버는_마지막에_온다() {
+        Member unverifiedMember = missionMembers.get(2).getMember();
+        MissionVerification missionVerificationOfMe = mock(MissionVerification.class);
+        MissionVerification missionVerification = mock(MissionVerification.class);
+        List<MissionVerification> missionVerifications = List.of(missionVerificationOfMe, missionVerification);
+
+        when(missionVerificationOfMe.getMember()).thenReturn(me);
+        when(missionVerificationOfMe.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(missionVerification.getMember()).thenReturn(missionMembers.get(1).getMember());
+        when(missionVerification.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(missionVerificationViewRepository.getMissionVerificationView(any(), any())).thenReturn(null);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.DESC, missionVerifications, missionMembers);
+        assertThat(responses.getLast().nickname()).isEqualTo(unverifiedMember.getNickname());
+    }
+
+    @Test
+    void 미션_인증_현황을_인증_시간_최신순으로_정렬한다() {
+        LocalDateTime now = LocalDateTime.now();
+        MissionVerification missionVerificationOfMe = mock(MissionVerification.class);
+        MissionVerification missionVerificationOfEarliest = mock(MissionVerification.class);
+        MissionVerification missionVerificationOfLatest = mock(MissionVerification.class);
+        List<MissionVerification> missionVerifications = List.of(
+                missionVerificationOfMe,
+                missionVerificationOfEarliest,
+                missionVerificationOfLatest
+        );
+
+        when(missionVerificationOfMe.getMember()).thenReturn(me);
+        when(missionVerificationOfMe.getCreatedAt()).thenReturn(now);
+
+        when(missionVerificationOfEarliest.getMember()).thenReturn(missionMembers.get(1).getMember());
+        when(missionVerificationOfEarliest.getCreatedAt()).thenReturn(now.minusHours(1));
+
+        when(missionVerificationOfLatest.getMember()).thenReturn(missionMembers.get(2).getMember());
+        when(missionVerificationOfLatest.getCreatedAt()).thenReturn(now.plusHours(1));
+
+        when(missionVerificationViewRepository.getMissionVerificationView(any(), any())).thenReturn(null);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.DESC, missionVerifications, missionMembers);
+        assertAll(
+                () -> assertThat(responses.get(0).nickname()).isEqualTo(me.getNickname()),
+                () -> assertThat(responses.get(1).nickname()).isEqualTo(missionVerificationOfLatest.getMember().getNickname()),
+                () -> assertThat(responses.get(2).nickname()).isEqualTo(missionVerificationOfEarliest.getMember().getNickname())
+        );
+    }
+
+    @Test
+    void 미션_인증_현황을_인증_시간_오래된순으로_정렬한다() {
+        LocalDateTime now = LocalDateTime.now();
+        MissionVerification missionVerificationOfMe = mock(MissionVerification.class);
+        MissionVerification missionVerificationOfEarliest = mock(MissionVerification.class);
+        MissionVerification missionVerificationOfLatest = mock(MissionVerification.class);
+        List<MissionVerification> missionVerifications = List.of(
+                missionVerificationOfMe,
+                missionVerificationOfEarliest,
+                missionVerificationOfLatest
+        );
+
+        when(missionVerificationOfMe.getMember()).thenReturn(me);
+        when(missionVerificationOfMe.getCreatedAt()).thenReturn(now);
+
+        when(missionVerificationOfEarliest.getMember()).thenReturn(missionMembers.get(1).getMember());
+        when(missionVerificationOfEarliest.getCreatedAt()).thenReturn(now.minusHours(1));
+
+        when(missionVerificationOfLatest.getMember()).thenReturn(missionMembers.get(2).getMember());
+        when(missionVerificationOfLatest.getCreatedAt()).thenReturn(now.plusHours(1));
+
+        when(missionVerificationViewRepository.getMissionVerificationView(any(), any())).thenReturn(null);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.ASC, missionVerifications, missionMembers);
+        assertAll(
+                () -> assertThat(responses.get(0).nickname()).isEqualTo(me.getNickname()),
+                () -> assertThat(responses.get(1).nickname()).isEqualTo(missionVerificationOfEarliest.getMember().getNickname()),
+                () -> assertThat(responses.get(2).nickname()).isEqualTo(missionVerificationOfLatest.getMember().getNickname())
+        );
+    }
+
+    @Test
+    void 내가_확인하지_않은_미션_인증_현황이_내가_확인한_미션_인증_현황의_앞에_온다() {
+        Mission mission = mock(Mission.class);
+        MissionVerification missionVerificationOfMe = mock(MissionVerification.class);
+        MissionVerification viewedMissionVerification = mock(MissionVerification.class);
+        MissionVerification unviewedMissionVerification = mock(MissionVerification.class);
+        List<MissionVerification> missionVerifications = List.of(
+                missionVerificationOfMe,
+                viewedMissionVerification,
+                unviewedMissionVerification
+        );
+        MissionVerificationView missionVerificationView = mock(MissionVerificationView.class);
+
+        when(mission.getId()).thenReturn(1L);
+
+        when(missionVerificationOfMe.getMember()).thenReturn(me);
+        when(missionVerificationOfMe.getMission()).thenReturn(mission);
+        when(missionVerificationOfMe.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(viewedMissionVerification.getId()).thenReturn(2L);
+        when(viewedMissionVerification.getMember()).thenReturn(missionMembers.get(1).getMember());
+        when(viewedMissionVerification.getMission()).thenReturn(mission);
+        when(viewedMissionVerification.getCreatedAt()).thenReturn(LocalDateTime.now());
+        
+        when(unviewedMissionVerification.getMember()).thenReturn(missionMembers.get(2).getMember());
+        when(unviewedMissionVerification.getMission()).thenReturn(mission);
+        when(unviewedMissionVerification.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(missionVerificationView.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(missionVerificationViewRepository.getMissionVerificationView(viewedMissionVerification.getId(), me.getId())).thenReturn(missionVerificationView);
+
+        List<MissionVerificationResponse> responses = missionVerificationResponseSorter.sort(me, MissionVerificationQuery.SortType.VERIFIED_AT, Sort.Direction.ASC, missionVerifications, missionMembers);
+        assertAll(
+                () -> assertThat(responses.get(0).nickname()).isEqualTo(me.getNickname()),
+                () -> assertThat(responses.get(1).nickname()).isEqualTo(unviewedMissionVerification.getMember().getNickname()),
+                () -> assertThat(responses.get(2).nickname()).isEqualTo(viewedMissionVerification.getMember().getNickname())
+        );
+    }
+}

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorterTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorterTest.java
@@ -178,8 +178,6 @@ class MissionVerificationResponseSorterTest {
         );
         MissionVerificationView missionVerificationView = mock(MissionVerificationView.class);
 
-        when(mission.getId()).thenReturn(1L);
-
         when(missionVerificationOfMe.getMember()).thenReturn(me);
         when(missionVerificationOfMe.getMission()).thenReturn(mission);
         when(missionVerificationOfMe.getCreatedAt()).thenReturn(LocalDateTime.now());
@@ -188,7 +186,7 @@ class MissionVerificationResponseSorterTest {
         when(viewedMissionVerification.getMember()).thenReturn(missionMembers.get(1).getMember());
         when(viewedMissionVerification.getMission()).thenReturn(mission);
         when(viewedMissionVerification.getCreatedAt()).thenReturn(LocalDateTime.now());
-        
+
         when(unviewedMissionVerification.getMember()).thenReturn(missionMembers.get(2).getMember());
         when(unviewedMissionVerification.getMission()).thenReturn(mission);
         when(unviewedMissionVerification.getCreatedAt()).thenReturn(LocalDateTime.now());

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
@@ -1,12 +1,12 @@
 package com.nexters.goalpanzi.application.mission;
 
+import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.domain.mission.Mission;
 import com.nexters.goalpanzi.domain.mission.MissionMember;
 import com.nexters.goalpanzi.domain.mission.MissionVerification;
 import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
 import com.nexters.goalpanzi.exception.BadRequestException;
 import com.nexters.goalpanzi.exception.ErrorCode;
-import com.nexters.goalpanzi.fixture.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 public class MissionVerificationValidatorTest {
 
+    Member member;
     Mission mission;
 
     @MockBean
@@ -35,13 +36,14 @@ public class MissionVerificationValidatorTest {
 
     @BeforeEach()
     void setUp() {
+        member = mock(Member.class);
         mission = mock(Mission.class);
         when(mission.getBoardCount()).thenReturn(10);
     }
 
     @Test
     void 이미_완주한_미션은_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 10);
+        MissionMember missionMember = new MissionMember(member, mission, 10);
 
         BadRequestException exception = assertThrows(BadRequestException.class, () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.ALREADY_COMPLETED_MISSION.getMessage(), exception.getMessage());
@@ -49,7 +51,7 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 중복된_인증은_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
+        MissionMember missionMember = new MissionMember(member, mission, 1);
 
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
                 .thenReturn(Optional.of(mock(MissionVerification.class)));
@@ -61,7 +63,7 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 미션_기간이_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
+        MissionMember missionMember = new MissionMember(member, mission, 1);
 
         when(mission.isMissionPeriod()).thenReturn(false);
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
@@ -74,7 +76,7 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 지정한_미션_요일이_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
+        MissionMember missionMember = new MissionMember(member, mission, 1);
 
         when(mission.isMissionPeriod()).thenReturn(true);
         when(mission.isMissionDay()).thenReturn(false);
@@ -88,7 +90,7 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 지정한_미션_시간대가_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
+        MissionMember missionMember = new MissionMember(member, mission, 1);
 
         when(mission.isMissionPeriod()).thenReturn(true);
         when(mission.isMissionDay()).thenReturn(true);

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 public class MissionVerificationValidatorTest {
 
-    Mission mockMission;
+    Mission mission;
 
     @MockBean
     private MissionVerificationRepository missionVerificationRepository;
@@ -35,13 +35,13 @@ public class MissionVerificationValidatorTest {
 
     @BeforeEach()
     void setUp() {
-        mockMission = mock(Mission.class);
-        when(mockMission.getBoardCount()).thenReturn(10);
+        mission = mock(Mission.class);
+        when(mission.getBoardCount()).thenReturn(10);
     }
 
     @Test
     void 이미_완주한_미션은_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 10);
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 10);
 
         BadRequestException exception = assertThrows(BadRequestException.class, () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
         assertEquals(ErrorCode.ALREADY_COMPLETED_MISSION.getMessage(), exception.getMessage());
@@ -49,7 +49,7 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 중복된_인증은_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
 
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
                 .thenReturn(Optional.of(mock(MissionVerification.class)));
@@ -61,9 +61,9 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 미션_기간이_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
 
-        when(mockMission.isMissionPeriod()).thenReturn(false);
+        when(mission.isMissionPeriod()).thenReturn(false);
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
                 .thenReturn(Optional.empty());
 
@@ -74,10 +74,10 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 지정한_미션_요일이_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
 
-        when(mockMission.isMissionPeriod()).thenReturn(true);
-        when(mockMission.isMissionDay()).thenReturn(false);
+        when(mission.isMissionPeriod()).thenReturn(true);
+        when(mission.isMissionDay()).thenReturn(false);
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
                 .thenReturn(Optional.empty());
 
@@ -88,11 +88,11 @@ public class MissionVerificationValidatorTest {
 
     @Test
     void 지정한_미션_시간대가_아니므로_검증에_실패한다() {
-        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 1);
 
-        when(mockMission.isMissionPeriod()).thenReturn(true);
-        when(mockMission.isMissionDay()).thenReturn(true);
-        when(mockMission.isMissionTime()).thenReturn(false);
+        when(mission.isMissionPeriod()).thenReturn(true);
+        when(mission.isMissionDay()).thenReturn(true);
+        when(mission.isMissionTime()).thenReturn(false);
         when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
                 .thenReturn(Optional.empty());
 

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
@@ -43,7 +43,7 @@ public class MissionVerificationValidatorTest {
     void 이미_완주한_미션은_검증에_실패한다() {
         MissionMember missionMember = new MissionMember(MemberFixture.create(), mission, 10);
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.ALREADY_COMPLETED_MISSION.getMessage(), exception.getMessage());
     }
 
@@ -55,7 +55,7 @@ public class MissionVerificationValidatorTest {
                 .thenReturn(Optional.of(mock(MissionVerification.class)));
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+                () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.DUPLICATE_VERIFICATION.getMessage(), exception.getMessage());
     }
 
@@ -68,7 +68,7 @@ public class MissionVerificationValidatorTest {
                 .thenReturn(Optional.empty());
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+                () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.NOT_VERIFICATION_PERIOD.getMessage(), exception.getMessage());
     }
 
@@ -82,7 +82,7 @@ public class MissionVerificationValidatorTest {
                 .thenReturn(Optional.empty());
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+                () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.NOT_VERIFICATION_DAY.getMessage(), exception.getMessage());
     }
 
@@ -97,7 +97,7 @@ public class MissionVerificationValidatorTest {
                 .thenReturn(Optional.empty());
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+                () -> missionVerificationValidator.validate(missionMember));
         assertEquals(ErrorCode.NOT_VERIFICATION_TIME.getMessage(), exception.getMessage());
     }
 }

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationValidatorTest.java
@@ -1,0 +1,103 @@
+package com.nexters.goalpanzi.application.mission;
+
+import com.nexters.goalpanzi.domain.mission.Mission;
+import com.nexters.goalpanzi.domain.mission.MissionMember;
+import com.nexters.goalpanzi.domain.mission.MissionVerification;
+import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
+import com.nexters.goalpanzi.exception.BadRequestException;
+import com.nexters.goalpanzi.exception.ErrorCode;
+import com.nexters.goalpanzi.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class MissionVerificationValidatorTest {
+
+    Mission mockMission;
+
+    @MockBean
+    private MissionVerificationRepository missionVerificationRepository;
+
+    @Autowired
+    private MissionVerificationValidator missionVerificationValidator;
+
+    @BeforeEach()
+    void setUp() {
+        mockMission = mock(Mission.class);
+        when(mockMission.getBoardCount()).thenReturn(10);
+    }
+
+    @Test
+    void 이미_완주한_미션은_검증에_실패한다() {
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 10);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        assertEquals(ErrorCode.ALREADY_COMPLETED_MISSION.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void 중복된_인증은_검증에_실패한다() {
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+
+        when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
+                .thenReturn(Optional.of(mock(MissionVerification.class)));
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        assertEquals(ErrorCode.DUPLICATE_VERIFICATION.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void 미션_기간이_아니므로_검증에_실패한다() {
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+
+        when(mockMission.isMissionPeriod()).thenReturn(false);
+        when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
+                .thenReturn(Optional.empty());
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        assertEquals(ErrorCode.NOT_VERIFICATION_PERIOD.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void 지정한_미션_요일이_아니므로_검증에_실패한다() {
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+
+        when(mockMission.isMissionPeriod()).thenReturn(true);
+        when(mockMission.isMissionDay()).thenReturn(false);
+        when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
+                .thenReturn(Optional.empty());
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        assertEquals(ErrorCode.NOT_VERIFICATION_DAY.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void 지정한_미션_시간대가_아니므로_검증에_실패한다() {
+        MissionMember missionMember = new MissionMember(MemberFixture.create(), mockMission, 1);
+
+        when(mockMission.isMissionPeriod()).thenReturn(true);
+        when(mockMission.isMissionDay()).thenReturn(true);
+        when(mockMission.isMissionTime()).thenReturn(false);
+        when(missionVerificationRepository.findByMemberIdAndMissionIdAndDate(any(), any(), any(LocalDate.class)))
+                .thenReturn(Optional.empty());
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> missionVerificationValidator.validateVerificationSubmission(missionMember));
+        assertEquals(ErrorCode.NOT_VERIFICATION_TIME.getMessage(), exception.getMessage());
+    }
+}

--- a/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
+++ b/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
@@ -1,8 +1,6 @@
 package com.nexters.goalpanzi.fixture;
 
 import com.nexters.goalpanzi.domain.member.CharacterType;
-import com.nexters.goalpanzi.domain.member.Member;
-import com.nexters.goalpanzi.domain.member.SocialType;
 
 public class MemberFixture {
     public static final Long MEMBER_ID = 1L;
@@ -18,8 +16,4 @@ public class MemberFixture {
     public static final CharacterType CHARACTER_HOST = CharacterType.BEAR;
     public static final CharacterType CHARACTER_MEMBER_A = CharacterType.BIRD;
     public static final CharacterType CHARACTER_MEMBER_B = CharacterType.CAT;
-
-    public static Member create() {
-        return Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.GOOGLE);
-    }
 }

--- a/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
+++ b/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
@@ -1,6 +1,8 @@
 package com.nexters.goalpanzi.fixture;
 
 import com.nexters.goalpanzi.domain.member.CharacterType;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.member.SocialType;
 
 public class MemberFixture {
     public static final Long MEMBER_ID = 1L;
@@ -16,4 +18,8 @@ public class MemberFixture {
     public static final CharacterType CHARACTER_HOST = CharacterType.BEAR;
     public static final CharacterType CHARACTER_MEMBER_A = CharacterType.BIRD;
     public static final CharacterType CHARACTER_MEMBER_B = CharacterType.CAT;
+
+    public static Member create() {
+        return Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.GOOGLE);
+    }
 }


### PR DESCRIPTION
## Issue Number

close: #77 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

미션 인증/정렬 로직 리팩토링

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- `MissionVerification`의 서비스 단에서 모든 정렬을 수행하면서 서비스 코드가 복잡해짐
  - `MissionVerificationResponseSorter`를 정의하여 서비스 코드와 정렬 로직을 분리함
- `MissionVerificationValidator` 를 정의하여 서비스 코드와 검증 로직을 분리함

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

`MissionValidator` 코드처럼 `MissionVerificationValidator`도 있으면 좋을 것 같아 같이 리팩토링 진행했습니다..!

+) 참여 로직 잠시 주석 처리하고 e2e 테스트 돌렸을 때 정상적으로 돌아갔습니다! (생성자 새롭게 정의해서 테스트 코드도 작성해보겠습니다..!)

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->