### PR TITLE
fix: 미션 인증 정렬 로직

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationResponseSorter.java
@@ -63,7 +63,15 @@ public class MissionVerificationResponseSorter {
     }
 
     private Comparator<MissionVerificationResponse> unviewedVerificationFirst() {
-        return Comparator.comparing(MissionVerificationResponse::viewedAt, Comparator.nullsFirst(Comparator.naturalOrder()));
+        return Comparator.comparing((MissionVerificationResponse response) -> {
+            if (response.verifiedAt() != null && response.viewedAt() == null) {
+                return 0;
+            }
+            if (response.verifiedAt() != null) {
+                return 1;
+            }
+            return 2;
+        });
     }
 
     private Comparator<MissionVerificationResponse> compareResponsesByOrder(final MissionVerificationQuery.SortType sortType, final Sort.Direction direction) {


### PR DESCRIPTION
## Issue Number

close: #68

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
`viewedAt`이 추가되면서 `viewedAt`이 `null`인 값들이 앞에 오게 되어 생긴 문제

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

`viewedAt`이 `null`인 경우는 두 가지 경우가 있다.
1. 인증하지 않은 경우
2. 인증했지만 내가 확인하지 않은 경우

두 가지 경우 중 2번만 가장 앞에 와야 하는데 `viewedAt`이 `null`인 경우가 모두 앞으로 오게 되면서 1번이 가장 앞에 오는 문제가 발생했다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
```diff
private Comparator<MissionVerificationResponse> unviewedVerificationFirst() {
-     return Comparator.comparing(MissionVerificationResponse::viewedAt, Comparator.nullsFirst(Comparator.naturalOrder()));
+    return Comparator.comparing((MissionVerificationResponse response) -> {
+        if (response.verifiedAt() != null && response.viewedAt() == null) { // 1. 인증했지만 내가 확인하지 않은 겻이 가장 먼저
+            return 0;
+        }
+        if (response.verifiedAt() != null) { // 2. 인증했지만 내가 확인한 것이 그 이후
+            return 1;
+        }
+        return 2; // 3. 인증하지 않은 것이 마지막에
+    });
}
```
## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->