### PR TITLE
feat: FCM 푸시 알림 일부 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,6 +73,7 @@ jobs:
             export OBJECT_STORAGE_BUCKET_NAME=${{ secrets.OBJECT_STORAGE_BUCKET_NAME }}
             export OBJECT_STORAGE_ACCESS_KEY_ID=${{ secrets.OBJECT_STORAGE_ACCESS_KEY_ID }}
             export OBJECT_STORAGE_SECRET_KEY=${{ secrets.OBJECT_STORAGE_SECRET_KEY }}
+            export ENCODED_FIREBASE_ADMIN_SDK=${{ secrets.ENCODED_FIREBASE_ADMIN_SDK }}
 
             sudo docker rm -f $(docker ps -qa)
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ out/
 .vscode/
 *.env
 *.log
-
-### Firebase ###
-**/firebase-adminsdk.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 *.env
 *.log
+
+### Firebase ###
+**/firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     // object storage
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/AuthService.java
@@ -34,6 +34,8 @@ public class AuthService {
         SocialUserInfo socialUserInfo = appleUserProvider.getSocialUserInfo(command.identityToken());
 
         return socialLogin(socialUserInfo, SocialType.APPLE);
+//        TODO 대체
+//        return socialLogin(socialUserInfo, SocialType.APPLE, command.deviceToken());
     }
 
     @Transactional
@@ -42,12 +44,17 @@ public class AuthService {
                 GoogleIdentityToken.generate(command.email()), command.email());
 
         return socialLogin(socialUserInfo, SocialType.GOOGLE);
+//        TODO 추후 대체
+//        return socialLogin(socialUserInfo, SocialType.GOOGLE, command.deviceToken());
     }
 
+    //    TODO 추후 대체
+//    private LoginResponse socialLogin(final SocialUserInfo socialUserInfo, final SocialType socialType, final String deviceToken) {
     private LoginResponse socialLogin(final SocialUserInfo socialUserInfo, final SocialType socialType) {
         checkDeletedMember(socialUserInfo.socialId());
         Member member = memberRepository.findBySocialIdAndDeletedAtIsNull(socialUserInfo.socialId())
                 .orElseGet(() ->
+                        // TODO device token 저장
                         memberRepository.save(Member.socialLogin(socialUserInfo.socialId(), socialUserInfo.email(), socialType))
                 );
 

--- a/src/main/java/com/nexters/goalpanzi/application/auth/dto/request/AppleLoginCommand.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/dto/request/AppleLoginCommand.java
@@ -6,5 +6,8 @@ import jakarta.validation.constraints.NotEmpty;
 public record AppleLoginCommand(
         @Schema(description = "애플 ID 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotEmpty String identityToken
+//        TODO 추후 활성화
+//        @Schema(description = "deviceToken", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+//        String deviceToken
 ) {
 }

--- a/src/main/java/com/nexters/goalpanzi/application/auth/dto/request/GoogleLoginCommand.java
+++ b/src/main/java/com/nexters/goalpanzi/application/auth/dto/request/GoogleLoginCommand.java
@@ -1,8 +1,13 @@
 package com.nexters.goalpanzi.application.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 
 public record GoogleLoginCommand(
+        @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotEmpty String email
+//        TODO 추후 활성화
+//        @Schema(description = "deviceToken", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+//        String deviceToken
 ) {
 }

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationMessage.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationMessage.java
@@ -1,0 +1,37 @@
+package com.nexters.goalpanzi.application.firebase;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum PushNotificationMessage {
+    // 미션 시작 전
+    MISSION_READY("미션 시작까지 1시간! 준비 갈 완료?\uD83C\uDF40", "이제 꾸준함을 향한 첫 발을 내딛을 시간!"),
+    MISSION_JOINED("엇? 누가 미션에 합류했어요! \uD83D\uDE4C", "이제 메이트 %s님과 미션 경쟁을 할 수 있어요."),
+    MISSION_CANCELLATION_WARNING("미션 폭파까지 30분 남았어요!\uD83E\uDDE8", "똑딱..똑딱.. 미션을 지키려면 인원이 필요해요!"),
+    MISSION_CANCELED("으악!\uD83D\uDCA5 인원이 부족해 미션이 삭제됐어요\uD83D\uDE35", "인원을 채워서 바로 다시 시작해봐요!"),
+
+    // 미션 진행 중
+    MISSION_VERIFICATION_WARNING("\u23F0 마감임박! 1시간 남았어요!\uD83E\uDDE8\uD83D\uDCA5", "지금 인증 안 하면 오늘은 인증 실패!ㅠㅠ"),
+    MISSION_VERIFIED("˗ˋˏ 와 ˎˊ˗ %s명이 벌써 인증 완료 ˗ˋˏ 와 ˎˊ˗ ", "지금 누가 앞서가는지 확인해볼까요?"),
+    MISSION_NO_ONE_VERIFIED("잊었니?..\uD83C\uDF42", "아직 아무도 인증 안 했어요! 1빠로 인증해 모두를 앞서갈 타이밍!"),
+    MISSION_COMPLETED("아니 글쎄..걔가 결국 1등 했다고?! \uD83D\uDDEF\uFE0F", "첫 번째 미션 완수자 등장! 빠르게 확인해 보세요!"),
+    MISSION_DELETED("뭐? 미션 끝났다고? 너 누군데? \uD83D\uDC40", "방장이 미션을 끝냈어요! 다음 미션에서 새롭게 만나요!"),
+
+    // 미션 종료 후
+    MISSION_RETRY("이제 다시 갓생 살 때가 된 것 같은데요? \uD83D\uDE0C", "미션이 끝난 지 7일째! 새로운 미션이 필요할 때죠?");
+
+    private String title;
+    private String body;
+
+    public String getTitle(final Object... args) {
+        return String.format(title, args);
+    }
+
+    public String getBody(final Object... args) {
+        return String.format(body, args);
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationMessage.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationMessage.java
@@ -1,12 +1,10 @@
 package com.nexters.goalpanzi.application.firebase;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
 public enum PushNotificationMessage {
     // 미션 시작 전
     MISSION_READY("미션 시작까지 1시간! 준비 갈 완료?\uD83C\uDF40", "이제 꾸준함을 향한 첫 발을 내딛을 시간!"),

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationSenderImpl.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/PushNotificationSenderImpl.java
@@ -1,0 +1,49 @@
+package com.nexters.goalpanzi.application.firebase;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.nexters.goalpanzi.exception.BaseException;
+import com.nexters.goalpanzi.exception.ErrorCode;
+import com.nexters.goalpanzi.infrastructure.firebase.PushNotificationSender;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PushNotificationSenderImpl implements PushNotificationSender {
+
+    public void sendIndividualMessage(final String title, final String body, final String token) {
+        Notification notification = makeNotification(title, body);
+        Message message = Message.builder()
+                .setNotification(notification)
+                .setToken(token)
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new BaseException(ErrorCode.FAILED_TO_SEND_INDIVIDUAL_MESSAGE);
+        }
+    }
+
+    public void sendGroupMessage(final String title, final String body, final String topic) {
+        Notification notification = makeNotification(title, body);
+        Message message = Message.builder()
+                .setNotification(notification)
+                .setTopic(topic)
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new BaseException(ErrorCode.FAILED_TO_SEND_GROUP_MESSAGE);
+        }
+    }
+
+    private Notification makeNotification(final String title, final String body) {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/TopicGenerator.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/TopicGenerator.java
@@ -1,0 +1,10 @@
+package com.nexters.goalpanzi.application.firebase;
+
+public class TopicGenerator {
+
+    private static final String TOPIC_PREFIX = "missionId#";
+
+    public static String getTopic(Long missionId) {
+        return TOPIC_PREFIX + missionId;
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/TopicSubscriberImpl.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/TopicSubscriberImpl.java
@@ -1,0 +1,30 @@
+package com.nexters.goalpanzi.application.firebase;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.nexters.goalpanzi.exception.BaseException;
+import com.nexters.goalpanzi.exception.ErrorCode;
+import com.nexters.goalpanzi.infrastructure.firebase.TopicSubscriber;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class TopicSubscriberImpl implements TopicSubscriber {
+
+    public void subscribeToTopic(final List<String> registrationTokens, final String topic) {
+        try {
+            FirebaseMessaging.getInstance().subscribeToTopic(registrationTokens, topic);
+        } catch (FirebaseMessagingException e) {
+            throw new BaseException(ErrorCode.FAILED_TO_SUBSCRIBE_TO_TOPIC);
+        }
+    }
+
+    public void unsubscribeFromTopic(final List<String> registrationTokens, final String topic) {
+        try {
+            FirebaseMessaging.getInstance().unsubscribeFromTopic(registrationTokens, topic);
+        } catch (FirebaseMessagingException e) {
+            throw new BaseException(ErrorCode.FAILED_TO_UNSUBSCRIBE_FROM_TOPIC);
+        }
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
@@ -6,17 +6,14 @@ import com.nexters.goalpanzi.application.mission.dto.response.MissionsResponse;
 import com.nexters.goalpanzi.domain.common.BaseEntity;
 import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
-import com.nexters.goalpanzi.domain.mission.InvitationCode;
-import com.nexters.goalpanzi.domain.mission.MemberRanks;
-import com.nexters.goalpanzi.domain.mission.Mission;
-import com.nexters.goalpanzi.domain.mission.MissionMember;
-import com.nexters.goalpanzi.domain.mission.MissionStatus;
+import com.nexters.goalpanzi.domain.mission.*;
 import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionRepository;
 import com.nexters.goalpanzi.exception.AlreadyExistsException;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,9 +25,12 @@ import java.util.List;
 public class MissionMemberService {
 
     private final MissionValidator missionValidator;
+
     private final MissionMemberRepository missionMemberRepository;
     private final MissionRepository missionRepository;
     private final MemberRepository memberRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     public MissionDetailResponse getJoinableMission(final InvitationCode invitationCode) {
         missionValidator.validateJoinableMission(invitationCode);
@@ -44,6 +44,9 @@ public class MissionMemberService {
         validateAlreadyJoin(member, mission);
         missionValidator.validateMaxPersonnel(mission);
         missionMemberRepository.save(MissionMember.join(member, mission));
+
+//        TODO
+//        eventPublisher.publishEvent(new JoinMissionEvent(mission.getId(), "TODO deviceToken", member.getNickname()));
     }
 
     private Mission getMissionByCode(final InvitationCode invitationCode) {

--- a/src/main/java/com/nexters/goalpanzi/application/mission/event/CompleteMissionEvent.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/event/CompleteMissionEvent.java
@@ -1,0 +1,7 @@
+package com.nexters.goalpanzi.application.mission.event;
+
+public record CompleteMissionEvent(
+        Long missionId,
+        String nickname
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/event/JoinMissionEvent.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/event/JoinMissionEvent.java
@@ -1,0 +1,8 @@
+package com.nexters.goalpanzi.application.mission.event;
+
+public record JoinMissionEvent(
+        Long missionId,
+        String deviceToken,
+        String nickname
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/event/VerifyMissionEvent.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/event/VerifyMissionEvent.java
@@ -1,0 +1,7 @@
+package com.nexters.goalpanzi.application.mission.event;
+
+public record VerifyMissionEvent(
+        Long missionId,
+        Integer verifiedMemberCount
+) {
+}

--- a/src/main/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandler.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandler.java
@@ -65,6 +65,7 @@ public class MissionMemberEventHandler {
         log.info("Handled DeleteMissionEvent for missionId: {}", event.missionId());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     void handleJoinMissionEvent(final JoinMissionEvent event) {
         String topic = TopicGenerator.getTopic(event.missionId());
@@ -78,6 +79,7 @@ public class MissionMemberEventHandler {
         log.info("Handled JoinMissionEvent for missionId: {}", event.missionId());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     void handleCompleteMissionEvent(final CompleteMissionEvent event) {
         pushNotificationSender.sendGroupMessage(

--- a/src/main/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandler.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandler.java
@@ -1,11 +1,16 @@
 package com.nexters.goalpanzi.application.mission.event.handler;
 
+import com.nexters.goalpanzi.application.firebase.TopicGenerator;
 import com.nexters.goalpanzi.application.member.event.DeleteMemberEvent;
 import com.nexters.goalpanzi.application.mission.MissionMemberService;
 import com.nexters.goalpanzi.application.mission.MissionVerificationService;
-import com.nexters.goalpanzi.application.mission.event.DeleteMissionEvent;
+import com.nexters.goalpanzi.application.mission.event.CompleteMissionEvent;
 import com.nexters.goalpanzi.application.mission.event.CreateMissionEvent;
+import com.nexters.goalpanzi.application.mission.event.DeleteMissionEvent;
+import com.nexters.goalpanzi.application.mission.event.JoinMissionEvent;
 import com.nexters.goalpanzi.domain.mission.InvitationCode;
+import com.nexters.goalpanzi.infrastructure.firebase.PushNotificationSender;
+import com.nexters.goalpanzi.infrastructure.firebase.TopicSubscriber;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -15,12 +20,19 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.List;
+
+import static com.nexters.goalpanzi.application.firebase.PushNotificationMessage.*;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class MissionMemberEventHandler {
     private final MissionMemberService missionMemberService;
     private final MissionVerificationService missionVerificationService;
+
+    private final PushNotificationSender pushNotificationSender;
+    private final TopicSubscriber topicSubscriber;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     void handleCreateMissionEvent(final CreateMissionEvent event) {
@@ -43,6 +55,37 @@ public class MissionMemberEventHandler {
     void handleDeleteMissionEvent(final DeleteMissionEvent event) {
         missionMemberService.deleteAllByMissionId(event.missionId());
         missionVerificationService.deleteAllByMissionId(event.missionId());
+        
+        pushNotificationSender.sendGroupMessage(
+                MISSION_DELETED.getTitle(),
+                MISSION_DELETED.getBody(),
+                TopicGenerator.getTopic(event.missionId())
+        );
+
         log.info("Handled DeleteMissionEvent for missionId: {}", event.missionId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void handleJoinMissionEvent(final JoinMissionEvent event) {
+        String topic = TopicGenerator.getTopic(event.missionId());
+        pushNotificationSender.sendGroupMessage(
+                MISSION_JOINED.getTitle(),
+                MISSION_JOINED.getBody(event.nickname()),
+                topic
+        );
+        topicSubscriber.subscribeToTopic(List.of(event.deviceToken()), topic);
+
+        log.info("Handled JoinMissionEvent for missionId: {}", event.missionId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void handleCompleteMissionEvent(final CompleteMissionEvent event) {
+        pushNotificationSender.sendGroupMessage(
+                MISSION_COMPLETED.getTitle(),
+                MISSION_COMPLETED.getBody(),
+                TopicGenerator.getTopic(event.missionId())
+        );
+
+        log.info("Handled CompleteMissionEvent for missionId: {}", event.missionId());
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
@@ -3,21 +3,27 @@ package com.nexters.goalpanzi.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Base64;
 
 @Configuration
 public class FirebaseConfig {
 
+    @Value("${firebase.admin-sdk}")
+    private String encodedFirebaseAdminSdk;
+
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase-adminsdk.json");
+        byte[] decodedBytes = Base64.getDecoder().decode(encodedFirebaseAdminSdk);
+        ByteArrayInputStream adminSdk = new ByteArrayInputStream(decodedBytes);
 
         FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .setCredentials(GoogleCredentials.fromStream(adminSdk))
                 .build();
         return FirebaseApp.initializeApp(options);
     }

--- a/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Base64;
 
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
 @Configuration
 public class FirebaseConfig {
 

--- a/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
@@ -1,0 +1,24 @@
+package com.nexters.goalpanzi.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase-adminsdk.json");
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/config/FirebaseConfig.java
@@ -5,7 +5,6 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.ByteArrayInputStream;
@@ -19,7 +18,6 @@ public class FirebaseConfig {
     @Value("${firebase.admin-sdk}")
     private String encodedFirebaseAdminSdk;
 
-    @Bean
     public FirebaseApp firebaseApp() throws IOException {
         byte[] decodedBytes = Base64.getDecoder().decode(encodedFirebaseAdminSdk);
         ByteArrayInputStream adminSdk = new ByteArrayInputStream(decodedBytes);

--- a/src/main/java/com/nexters/goalpanzi/domain/member/Member.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/member/Member.java
@@ -1,14 +1,7 @@
 package com.nexters.goalpanzi.domain.member;
 
 import com.nexters.goalpanzi.domain.common.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,10 +36,21 @@ public class Member extends BaseEntity {
     @Column(name = "character_type")
     private CharacterType characterType;
 
+    // TODO
+    @Column(name = "device_token")
+    private String deviceToken;
+
     private Member(final String socialId, final String email, final SocialType socialType) {
         this.socialId = socialId;
         this.email = email;
         this.socialType = socialType;
+    }
+
+    private Member(final String socialId, final String email, final SocialType socialType, final String deviceToken) {
+        this.socialId = socialId;
+        this.email = email;
+        this.socialType = socialType;
+        this.deviceToken = deviceToken;
     }
 
     public static Member socialLogin(final String socialId, final String email, final SocialType socialType) {
@@ -55,6 +59,14 @@ public class Member extends BaseEntity {
         }
 
         return new Member(socialId, email, socialType);
+    }
+
+    public static Member socialLogin(final String socialId, final String email, final SocialType socialType, final String deviceToken) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("사용자 정보가 올바르지 않습니다.");
+        }
+
+        return new Member(socialId, email, socialType, deviceToken);
     }
 
     public Boolean isProfileSet() {

--- a/src/main/java/com/nexters/goalpanzi/exception/ErrorCode.java
+++ b/src/main/java/com/nexters/goalpanzi/exception/ErrorCode.java
@@ -45,6 +45,12 @@ public enum ErrorCode {
     INVALID_FILE("유효하지 않은 파일입니다."),
     FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다. [%s]"),
 
+    // FIREBASE
+    FAILED_TO_SEND_INDIVIDUAL_MESSAGE("개인 푸시 알림을 보내는 데 실패하였습니다."),
+    FAILED_TO_SEND_GROUP_MESSAGE("그룹 푸시 알림을 보내는 데 실패하였습니다."),
+    FAILED_TO_SUBSCRIBE_TO_TOPIC("토픽을 구독하는 데 실패하였습니다."),
+    FAILED_TO_UNSUBSCRIBE_FROM_TOPIC("토픽을 구독 취소하는 데 실패하였습니다."),
+
     // ETC
     FAILED_TO_GENERATE_HASH("해시값을 생성하는 데 실패하였습니다.");
 

--- a/src/main/java/com/nexters/goalpanzi/infrastructure/firebase/PushNotificationSender.java
+++ b/src/main/java/com/nexters/goalpanzi/infrastructure/firebase/PushNotificationSender.java
@@ -1,0 +1,8 @@
+package com.nexters.goalpanzi.infrastructure.firebase;
+
+public interface PushNotificationSender {
+
+    void sendIndividualMessage(final String title, final String body, final String token);
+
+    void sendGroupMessage(final String title, final String body, final String topic);
+}

--- a/src/main/java/com/nexters/goalpanzi/infrastructure/firebase/TopicSubscriber.java
+++ b/src/main/java/com/nexters/goalpanzi/infrastructure/firebase/TopicSubscriber.java
@@ -1,0 +1,10 @@
+package com.nexters.goalpanzi.infrastructure.firebase;
+
+import java.util.List;
+
+public interface TopicSubscriber {
+
+    void subscribeToTopic(final List<String> registrationTokens, final String topic);
+
+    void unsubscribeFromTopic(final List<String> registrationTokens, final String topic);
+}

--- a/src/main/java/com/nexters/goalpanzi/presentation/fcmtest/FcmTestController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/fcmtest/FcmTestController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Tag(name = "푸시 알림 테스트")
 @RequiredArgsConstructor
-@RequestMapping("/api/fcm-test")
+@RequestMapping("/internal/fcm-test")
 @RestController
 public class FcmTestController {
 

--- a/src/main/java/com/nexters/goalpanzi/presentation/fcmtest/FcmTestController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/fcmtest/FcmTestController.java
@@ -1,0 +1,49 @@
+package com.nexters.goalpanzi.presentation.fcmtest;
+
+import com.nexters.goalpanzi.infrastructure.firebase.PushNotificationSender;
+import com.nexters.goalpanzi.infrastructure.firebase.TopicSubscriber;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "푸시 알림 테스트")
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm-test")
+@RestController
+public class FcmTestController {
+
+    private final PushNotificationSender pushNotificationSender;
+    private final TopicSubscriber topicSubscriber;
+
+    @Operation(summary = "개별 메시지 전송")
+    @GetMapping("individual-message")
+    ResponseEntity<Void> sendIndividualMessage(
+            @Schema(description = "deviceToken", requiredMode = Schema.RequiredMode.REQUIRED)
+            @RequestBody final String deviceToken) {
+        pushNotificationSender.sendIndividualMessage("개별 메시지 테스트", deviceToken + "으로 개별 메시지를 전송합니다.", deviceToken);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "그룹 메시지 전송")
+    @GetMapping("group-message")
+    ResponseEntity<Void> sendGroupMessage(
+            @Schema(description = "deviceToken", requiredMode = Schema.RequiredMode.REQUIRED)
+            @RequestBody final String deviceToken
+    ) {
+        String topic = "topic-test";
+        topicSubscriber.subscribeToTopic(List.of(deviceToken), topic);
+        pushNotificationSender.sendGroupMessage("그룹 메시지 테스트", topic + "으로 그룹 메시지를 전송합니다.", topic);
+        topicSubscriber.unsubscribeFromTopic(List.of(deviceToken), topic);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,4 +65,5 @@ cloud:
       endpoint: https://kr.object.ncloudstorage.com
 
 firebase:
+  enabled: true
   admin-sdk: ${ENCODED_FIREBASE_ADMIN_SDK}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,6 @@ cloud:
       auto: false
     s3:
       endpoint: https://kr.object.ncloudstorage.com
+
+firebase:
+  admin-sdk: ${ENCODED_FIREBASE_ADMIN_SDK}

--- a/src/main/resources/db/migration/V6__add_member_device_token_col.sql;
+++ b/src/main/resources/db/migration/V6__add_member_device_token_col.sql;
@@ -1,0 +1,2 @@
+alter table member
+    add device_token varchar(152) null;

--- a/src/test/java/com/nexters/goalpanzi/acceptance/LoginAcceptanceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/acceptance/LoginAcceptanceTest.java
@@ -36,6 +36,8 @@ public class LoginAcceptanceTest extends AcceptanceTest {
     void 사용자가_애플_로그인을_정상적으로_한다() throws NoSuchAlgorithmException {
         String appleToken = TokenFixture.generateAppleToken();
         AppleLoginCommand request = new AppleLoginCommand(appleToken);
+//        TODO 추후 대체
+//        AppleLoginCommand request = new AppleLoginCommand(appleToken, DEVICE_TOKEN);
 
         when(socialUserProviderFactory.getProvider(any()))
                 .thenReturn(socialUserProvider);
@@ -61,6 +63,8 @@ public class LoginAcceptanceTest extends AcceptanceTest {
     @Test
     void 사용자가_구글_로그인을_정상적으로_한다() {
         GoogleLoginCommand request = new GoogleLoginCommand(EMAIL_HOST);
+//        TODO 추후 대체
+//        GoogleLoginCommand request = new GoogleLoginCommand(EMAIL_HOST, DEVICE_TOKEN);
 
         LoginResponse actual = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -81,9 +85,13 @@ public class LoginAcceptanceTest extends AcceptanceTest {
     @Test
     void 사용자가_탈퇴후_재가입한다() {
         LoginResponse login = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+//        TODO 추후 대체
+//        LoginResponse login = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST, DEVICE_TOKEN)).as(LoginResponse.class);
         회원_탈퇴(login.memberId(), login.accessToken());
 
         LoginResponse actual = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST)).as(LoginResponse.class);
+//        TODO 추후 대체
+//        LoginResponse actual = 구글_로그인(new GoogleLoginCommand(EMAIL_HOST, DEVICE_TOKEN)).as(LoginResponse.class);
 
         assertThat(actual.memberId()).isNotNull();
     }

--- a/src/test/java/com/nexters/goalpanzi/domain/member/MemberTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/member/MemberTest.java
@@ -9,7 +9,7 @@ class MemberTest {
 
     @Test
     void 닉네임_설정이_가능하다() {
-        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
+        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE, DEVICE_TOKEN);
         member.updateNickname(NICKNAME_HOST);
 
         assertThat(member.getNickname()).isEqualTo(NICKNAME_HOST);
@@ -17,15 +17,15 @@ class MemberTest {
 
     @Test
     void 장기말타입_설정이_가능하다() {
-        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
+        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE, DEVICE_TOKEN);
         member.updateCharacterType(CHARACTER_HOST);
 
         assertThat(member.getCharacterType()).isEqualTo(CHARACTER_HOST);
     }
 
     @Test
-    void 닉네임과_장기말타입_전부_설정시_프로필_설정여부를_true로_반환한다(){
-        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
+    void 닉네임과_장기말타입_전부_설정시_프로필_설정여부를_true로_반환한다() {
+        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE, DEVICE_TOKEN);
         member.updateNickname(NICKNAME_HOST);
         member.updateCharacterType(CHARACTER_HOST);
 
@@ -33,8 +33,8 @@ class MemberTest {
     }
 
     @Test
-    void 닉네임과_장기말타입_중_하나라도_설정되지_않은경우_프로필_설정여부를_false로_반환한다(){
-        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
+    void 닉네임과_장기말타입_중_하나라도_설정되지_않은경우_프로필_설정여부를_false로_반환한다() {
+        Member member = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE, DEVICE_TOKEN);
         member.updateNickname(NICKNAME_HOST);
 
         assertThat(member.isProfileSet()).isFalse();

--- a/src/test/java/com/nexters/goalpanzi/domain/mission/MemberRanksTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/mission/MemberRanksTest.java
@@ -16,9 +16,9 @@ class MemberRanksTest {
     @Test
     void 미션_최종_등수를_확인할_수_있다() {
         // given
-        Member memberHost = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE);
-        Member memberA = Member.socialLogin(SOCIAL_ID, EMAIL_MEMBER_A, SocialType.APPLE);
-        Member memberB = Member.socialLogin(SOCIAL_ID, EMAIL_MEMBER_B, SocialType.GOOGLE);
+        Member memberHost = Member.socialLogin(SOCIAL_ID, EMAIL_HOST, SocialType.APPLE, DEVICE_TOKEN);
+        Member memberA = Member.socialLogin(SOCIAL_ID, EMAIL_MEMBER_A, SocialType.APPLE, DEVICE_TOKEN);
+        Member memberB = Member.socialLogin(SOCIAL_ID, EMAIL_MEMBER_B, SocialType.GOOGLE, DEVICE_TOKEN);
 
         List<MissionMember> missionMembers = List.of(
                 new MissionMember(memberHost, MissionFixture.create(), 10),

--- a/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
+++ b/src/test/java/com/nexters/goalpanzi/fixture/MemberFixture.java
@@ -4,6 +4,7 @@ import com.nexters.goalpanzi.domain.member.CharacterType;
 
 public class MemberFixture {
     public static final Long MEMBER_ID = 1L;
+    public static final String DEVICE_TOKEN = "device_token";
     public static final String ID_TOKEN_HOST = "token_host";
     public static final String ID_TOKEN_MEMBER_A = "token_member_A";
     public static final String EMAIL_HOST = "host@gmail.com";

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -39,3 +39,7 @@ cloud:
       auto: false
     s3:
       endpoint: https://kr.object.ncloudstorage.com
+
+firebase:
+  enabled: false
+  admin-sdk: --


### PR DESCRIPTION
## Issue Number

#84 
(FCM 테스트가 필요해서 `close` 뺐습니닷)

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- [푸시 알림 기획](https://www.notion.so/teamnexters/8a209196785d40dab674800a5406fd85)을 바탕으로 FCM 푸시 로직 일부 작성
- 푸시 알림 테스트를 위한 API 작성 (추후 삭제 예정)

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

푸시 알림 종류를 다음과 같이 분류하여 작업 중입니다.

- 트리거 방식에 따른 분류
  - 이벤트 : 사용자 액션에 의해 트리거되는 경우
    - ex. `친구 입장 안내 알림`, `미션 삭제 알림`
  - 스케줄러 : 특정 시점에 트리거되는 경우
    - ex. `미션 시작 예고 알림`, `미션 취소 알림`
- 알림 대상
  - 개인
    - ex. `새로운 미션 독려 알림`
  - 그룹

구현 방법
- 이벤트 - 스프링 이벤트, 스케줄러 - 스프링 쿼츠 활용 예정 (이벤트는 구현 중, 스케줄러는 구현 예정)
- 개인 메시지 - 디바이스 토큰, 그룹 메시지 - 토픽 활용 예정

> 토픽은 일종의 채널로 보시면 됩니당
> 토픽으로 해당 토픽을 구독한 모든 사용자에게 동시에 메시지를 보낼 수 있대요...!


## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
푸시 알림 테스트를 백엔드 단독으로 진행하기 어려워 일부 구현 사항을 테스트 컨트롤러와 함께 올립니다.. 🙏

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
