### PR TITLE
fix: 스케줄러 잡 실행시 스프링 컨텍스트 내에서 찾도록 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/#82-fix-scheduler
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-      - fix/#82-fix-mission-status
+      - fix/#82-fix-scheduler
 
 jobs:
   build-and-push:

--- a/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
@@ -23,7 +23,7 @@ public class MissionStatusJob extends AbstractJob<CronTrigger> implements Custom
     @Override
     protected ScheduleBuilder<CronTrigger> getScheduleBuilder() {
         // 00:00, 06:00, 12:00, 18:00 마다 실행
-        return CronScheduleBuilder.cronSchedule("0 40 16 * * ?")
+        return CronScheduleBuilder.cronSchedule("0 45 16 * * ?")
                 .withMisfireHandlingInstructionDoNothing();
     }
 

--- a/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
@@ -1,7 +1,6 @@
 package com.nexters.goalpanzi.schedule;
 
 import com.nexters.goalpanzi.application.mission.MissionMemberService;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.StopWatch;
@@ -23,7 +22,7 @@ public class MissionStatusJob extends AbstractJob<CronTrigger> implements Custom
     @Override
     protected ScheduleBuilder<CronTrigger> getScheduleBuilder() {
         // 00:00, 06:00, 12:00, 18:00 마다 실행
-        return CronScheduleBuilder.cronSchedule("0 45 16 * * ?")
+        return CronScheduleBuilder.cronSchedule("0 0 */6 * * ?")
                 .withMisfireHandlingInstructionDoNothing();
     }
 

--- a/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/MissionStatusJob.java
@@ -1,6 +1,7 @@
 package com.nexters.goalpanzi.schedule;
 
 import com.nexters.goalpanzi.application.mission.MissionMemberService;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.StopWatch;
@@ -22,7 +23,7 @@ public class MissionStatusJob extends AbstractJob<CronTrigger> implements Custom
     @Override
     protected ScheduleBuilder<CronTrigger> getScheduleBuilder() {
         // 00:00, 06:00, 12:00, 18:00 마다 실행
-        return CronScheduleBuilder.cronSchedule("0 0 */6 * * ?")
+        return CronScheduleBuilder.cronSchedule("0 40 16 * * ?")
                 .withMisfireHandlingInstructionDoNothing();
     }
 

--- a/src/main/java/com/nexters/goalpanzi/schedule/SchedulerConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/SchedulerConfig.java
@@ -6,18 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDetail;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.scheduling.quartz.SchedulerFactoryBean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
+@Configuration
 public class SchedulerConfig {
     private final Scheduler scheduler;
     private final List<CustomAutomationJob> jobList;

--- a/src/main/java/com/nexters/goalpanzi/schedule/SchedulerFactoryConfig.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/SchedulerFactoryConfig.java
@@ -1,10 +1,12 @@
 package com.nexters.goalpanzi.schedule;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
 
 @Configuration
 public class SchedulerFactoryConfig {
@@ -22,11 +24,20 @@ public class SchedulerFactoryConfig {
     }
 
     @Bean
+    public SpringBeanJobFactory jobFactory(ApplicationContext ctx) {
+        SpringBeanJobFactory springBeanJobFactory = new SpringBeanJobFactory();
+        springBeanJobFactory.setApplicationContext(ctx);
+        return springBeanJobFactory;
+    }
+
+    @Bean
     public SchedulerFactoryBean schedulerFactory(
-            @Qualifier(SCHEDULER_THREAD_POOL_EXECUTOR) ThreadPoolTaskExecutor threadPoolTaskExecutor
+            @Qualifier(SCHEDULER_THREAD_POOL_EXECUTOR) ThreadPoolTaskExecutor threadPoolTaskExecutor,
+            SpringBeanJobFactory jobFactory
     ) {
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
         factory.setTaskExecutor(threadPoolTaskExecutor);
+        factory.setJobFactory(jobFactory);
         return factory;
     }
 }


### PR DESCRIPTION
## Issue Number

close: #

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
스레드풀 별도로 관리하려고 SpringBeanJobFactory 명시적으로 빈 생성했는데 Job 실행시 스프링 컨텍스트 내에서 찾지 않고 매번 실행하는 방식으로 동작해서 해당 동작 변경했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
여기에 작성하세요

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
