### PR TITLE
fix: duration 계산, fcm 토픽 형식 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - fix/#84-fcm-push
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/#84-fcm-push
 
 jobs:
   build-and-push:

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/TopicGenerator.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/TopicGenerator.java
@@ -2,7 +2,7 @@ package com.nexters.goalpanzi.application.firebase;
 
 public class TopicGenerator {
 
-    private static final String TOPIC_PREFIX = "missionId#";
+    private static final String TOPIC_PREFIX = "/topics/missionId_";
 
     public static String getTopic(Long missionId) {
         return TOPIC_PREFIX + missionId;

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -165,10 +165,10 @@ public class Mission extends BaseEntity {
     // 1. 인증 시간이 오전인 경우, 09시에 푸시
     // 2. 인증 시간이 오후이거나 종일인 경우, 15시에 푸시
     public boolean isPushTime(final int hour) {
-        if (this.uploadStartTime.equals(TimeOfDay.MORNING.getStartTime())) {
+        if (this.uploadStartTime.equals(TimeOfDay.MORNING.getStartTime()) && this.uploadEndTime.equals(TimeOfDay.MORNING.getEndTime())) {
             return hour == PushTime.MORNING.getHour();
         }
-        if (this.uploadStartTime.equals(TimeOfDay.AFTERNOON.getStartTime())) {
+        if (this.uploadStartTime.equals(TimeOfDay.AFTERNOON.getStartTime()) && this.uploadEndTime.equals(TimeOfDay.AFTERNOON.getEndTime())) {
             return hour == PushTime.AFTERNOON.getHour();
         }
         return hour == PushTime.EVERYDAY.getHour();

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -156,7 +156,7 @@ public class Mission extends BaseEntity {
     // 미션 시작 예고 시간 == 미션 시작 1시간 전
     public boolean isReadyTime() {
         LocalDateTime startTime = LocalDateTime.of(this.missionStartDate.toLocalDate(), LocalTime.parse(this.uploadStartTime));
-        Duration duration = Duration.between(startTime, LocalDate.now());
+        Duration duration = Duration.between(startTime, LocalDateTime.now());
 
         return duration.isNegative() && duration.toHours() <= 1;
     }

--- a/src/main/java/com/nexters/goalpanzi/schedule/MissionCancellationWarningPushJob.java
+++ b/src/main/java/com/nexters/goalpanzi/schedule/MissionCancellationWarningPushJob.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,7 +22,6 @@ public class MissionCancellationWarningPushJob extends AbstractJob<CronTrigger> 
     }
 
     @Override
-    @Transactional
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         missionMemberService.sendCancellationWarningPushMessage();
     }

--- a/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
@@ -2,12 +2,12 @@ package com.nexters.goalpanzi.domain.mission;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.nexters.goalpanzi.fixture.MemberFixture.MEMBER_ID;
-import static com.nexters.goalpanzi.fixture.MissionFixture.BOARD_COUNT;
-import static com.nexters.goalpanzi.fixture.MissionFixture.DESCRIPTION;
+import static com.nexters.goalpanzi.fixture.MissionFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -75,5 +75,115 @@ class MissionTest {
                 InvitationCode.generate()
         );
         assertThat(mission.isExpired()).isTrue();
+    }
+
+    @Test
+    void 오늘이_미션_인증_요일이면_true를_반환한다() {
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.EVERYDAY,
+                WEEK,
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isMissionDay()).isTrue();
+    }
+
+    @Test
+    void 오늘이_미션_인증_요일이_아니면_false를_반환한다() {
+        List<DayOfWeek> missionDays = WEEK.stream()
+                .filter(d -> d != DayOfWeek.valueOf(LocalDate.now().getDayOfWeek().name())).toList();
+
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.EVERYDAY,
+                missionDays,
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isMissionDay()).isFalse();
+    }
+
+    @Test
+    void 현재_시간이_미션_인증_시간이면_true를_반환한다() {
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.EVERYDAY,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isMissionTime()).isTrue();
+    }
+
+    @Test
+    void 현재_시간이_미션_인증_시간이_아니면_false를_반환한다() {
+        TimeOfDay timeOfDay = (LocalDateTime.now().getHour() < 12) ? TimeOfDay.AFTERNOON : TimeOfDay.MORNING;
+
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                timeOfDay,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isMissionTime()).isFalse();
+    }
+
+    @Test
+    void 인증_시간이_오전인_미션은_푸시_알림_시간이_09시이다() {
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.MORNING,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isPushTime(9)).isTrue();
+    }
+
+    @Test
+    void 인증_시간이_오후인_미션은_푸시_알림_시간이_15시이다() {
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.AFTERNOON,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isPushTime(15)).isTrue();
+    }
+
+    @Test
+    void 인증_시간이_종일인_미션은_푸시_알림_시간이_15시이다() {
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30),
+                TimeOfDay.EVERYDAY,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        assertThat(mission.isPushTime(15)).isTrue();
     }
 }


### PR DESCRIPTION
## Issue Number

close: #

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

- duration 계산 오류

```
Unable to obtain LocalDateTime from TemporalAccessor: 2024-11-10 of type java.time.LocalDate
```
`LocalDate`에서 `LocalDateTime`을 얻으려고 하면서 발생

- fcm 토픽 형식 오류

```
Malformed topic name
```

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
`Duration.between` 에 전달하는 2번째 매개변수 `LocalDateTime`으로 변경
```diff
LocalDateTime startTime = LocalDateTime.of(this.missionStartDate.toLocalDate(), LocalTime.parse(this.uploadStartTime));
- Duration duration = Duration.between(startTime, LocalDate.now());
+ Duration duration = Duration.between(startTime, LocalDateTime.now());
```


[FCM 토픽 메시지 형식](https://github.com/firebase/firebase-admin-java/blob/feaa092802ab1a7b0170eb601c12eedb39c81eeb/src/main/java/com/google/firebase/messaging/Message.java#L149)에 벗어나지 않도록 수정

```diff
- private static final String TOPIC_PREFIX = "missionId#";
+ private static final String TOPIC_PREFIX = "/topics/missionId_"
```

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
