### PR TITLE
fix: 인증 마감 경고 시간 검증 추가

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionVerificationService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -109,7 +110,7 @@ public class MissionVerificationService {
         List<Mission> missions = missionRepository.getInProgressMissions();
 
         missions.forEach(mission -> {
-            if (mission.isMissionDay() && mission.isPushTime(hour)) {
+            if (mission.isMissionDay() && mission.isVerificationStatusPushTime(hour)) {
                 List<MissionVerification> verifications = missionVerificationRepository.findAllByMissionIdAndDate(mission.getId(), today);
                 int verificationCount = verifications.size();
 
@@ -145,11 +146,11 @@ public class MissionVerificationService {
     @Transactional
     public void sendVerificationWarningPushMessage() {
         LocalDate today = LocalDate.now();
-        int hour = LocalDateTime.now().getHour();
+        LocalTime time = LocalTime.now();
         List<Mission> missions = missionRepository.getInProgressMissions();
 
         missions.forEach(mission -> {
-            if (mission.isMissionDay()) {
+            if (mission.isMissionDay() && mission.isVerificationWarningPushTime(time)) {
                 List<MissionMember> missionMembers = missionMemberRepository.findAllByMissionId(mission.getId());
 
                 missionMembers.forEach(missionMember -> {

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -177,14 +177,27 @@ public class Mission extends BaseEntity {
     }
 
     /**
-     * <b>현재 시간이 푸시 시간인지 검증</b> <br>
+     * <b>현재 시간이 미션 인증 경고 시간인지 검증</b> <br>
+     * 미션 인증 경고 시간 == 미션 인증 마감 1시간 전
+     *
+     * @param now 현재 시각
+     * @return 미션 인증 경고 시간 여부
+     */
+    public boolean isVerificationWarningPushTime(final LocalTime now) {
+        Duration duration = Duration.between(now, TimeUtil.of(uploadEndTime));
+
+        return duration.isPositive() && duration.toHours() <= 1;
+    }
+
+    /**
+     * <b>현재 시간이 인증 현황 안내 시간인지 검증</b> <br>
      * 1. 인증 시간이 오전인 경우, 09시에 푸시 <br>
      * 2. 인증 시간이 오후이거나 종일인 경우, 15시에 푸시
      *
      * @param hour 현재 시각의 시간
-     * @return 미션 인증 푸시 시간 여부
+     * @return 미션 인증 현황 안내 시간 여부
      */
-    public boolean isPushTime(final int hour) {
+    public boolean isVerificationStatusPushTime(final int hour) {
         if (uploadStartTime.equals(TimeOfDay.MORNING.getStartTime()) && uploadEndTime.equals(TimeOfDay.MORNING.getEndTime())) {
             return hour == PushTime.MORNING.getHour();
         }

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationServiceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionVerificationServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,7 +74,7 @@ class MissionVerificationServiceTest {
 
         when(mockMission.getId()).thenReturn(MISSION_ID);
         when(mockMission.isMissionDay()).thenReturn(true);
-        when(mockMission.isPushTime(anyInt())).thenReturn(true);
+        when(mockMission.isVerificationStatusPushTime(anyInt())).thenReturn(true);
 
         when(missionRepository.getInProgressMissions()).thenReturn(List.of(mockMission));
         when(missionVerificationRepository.findAllByMissionIdAndDate(MISSION_ID, LocalDate.now())).thenReturn(verifications);
@@ -94,7 +95,7 @@ class MissionVerificationServiceTest {
 
         when(mockMission.getId()).thenReturn(MISSION_ID);
         when(mockMission.isMissionDay()).thenReturn(true);
-        when(mockMission.isPushTime(anyInt())).thenReturn(true);
+        when(mockMission.isVerificationStatusPushTime(anyInt())).thenReturn(true);
 
         when(missionRepository.getInProgressMissions()).thenReturn(List.of(mockMission));
         when(missionVerificationRepository.findAllByMissionIdAndDate(MISSION_ID, LocalDate.now())).thenReturn(List.of());
@@ -110,7 +111,7 @@ class MissionVerificationServiceTest {
     }
 
     @Test
-    void 미션을_인증하지_않은_경우_MISSION_VERIFICATION_WARNING_푸시_알림을_보낸다() {
+    void 미션을_인증하지_않았고_인증_마감_경고_시간인_경우_MISSION_VERIFICATION_WARNING_푸시_알림을_보낸다() {
         Long MEMBER_ID = 2L;
         Mission mockMission = mock(Mission.class);
         MissionMember mockMissionMember = mock(MissionMember.class);
@@ -119,6 +120,7 @@ class MissionVerificationServiceTest {
 
         when(mockMission.getId()).thenReturn(MISSION_ID);
         when(mockMission.isMissionDay()).thenReturn(true);
+        when(mockMission.isVerificationWarningPushTime(any(LocalTime.class))).thenReturn(true);
 
         when(mockMissionMember.getMember()).thenReturn(mockMember);
 

--- a/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
@@ -1,9 +1,11 @@
 package com.nexters.goalpanzi.domain.mission;
 
+import com.nexters.goalpanzi.common.time.TimeUtil;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.nexters.goalpanzi.fixture.MemberFixture.MEMBER_ID;
@@ -154,7 +156,7 @@ class MissionTest {
                 BOARD_COUNT,
                 InvitationCode.generate()
         );
-        assertThat(mission.isPushTime(9)).isTrue();
+        assertThat(mission.isVerificationStatusPushTime(9)).isTrue();
     }
 
     @Test
@@ -169,7 +171,7 @@ class MissionTest {
                 BOARD_COUNT,
                 InvitationCode.generate()
         );
-        assertThat(mission.isPushTime(15)).isTrue();
+        assertThat(mission.isVerificationStatusPushTime(15)).isTrue();
     }
 
     @Test
@@ -184,7 +186,7 @@ class MissionTest {
                 BOARD_COUNT,
                 InvitationCode.generate()
         );
-        assertThat(mission.isPushTime(15)).isTrue();
+        assertThat(mission.isVerificationStatusPushTime(15)).isTrue();
     }
 
     @Test
@@ -204,6 +206,27 @@ class MissionTest {
         assertAll(
                 () -> assertThat(mission.isReadyTime(mission.getMissionUploadStartDateTime().minusHours(1))).isTrue(),
                 () -> assertThat(mission.isReadyTime(mission.getMissionUploadStartDateTime().minusMinutes(30))).isTrue()
+        );
+    }
+
+    @Test
+    void 미션_인증_마감까지_1시간_덜_남은_경우_미션_인증_경고_시간이다() {
+        LocalDateTime now = LocalDateTime.now();
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                now,
+                now.plusDays(30),
+                TimeOfDay.EVERYDAY,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+        LocalTime uploadEndTime = TimeUtil.of(mission.getUploadEndTime());
+
+        assertAll(
+                () -> assertThat(mission.isVerificationWarningPushTime(uploadEndTime.minusHours(1))).isTrue(),
+                () -> assertThat(mission.isVerificationWarningPushTime(uploadEndTime.minusMinutes(30))).isTrue()
         );
     }
 }


### PR DESCRIPTION
## Issue Number

close: #

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

(#84)

- 문제 상황 : 오전/오후/종일 미션 관계없이 미션 인증날 11시, 23시에 인증 마감 경고 푸시가 감
- 해결 : `isVerificationWarningPushTime`을 추가하여 인증 마감까지 1시간 남았는지 검증

```java
public boolean isVerificationWarningPushTime(final LocalTime now) {
   Duration duration = Duration.between(now, TimeUtil.of(uploadEndTime));

    return duration.isPositive() && duration.toHours() <= 1;
}
```

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
여기에 작성하세요

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
