### PR TITLE
fix: 분산락 동시성 문제 해결

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
@@ -62,8 +62,12 @@ public class MissionMemberService {
         missionValidator.validateMaxPersonnel(mission);
         missionMemberRepository.save(MissionMember.join(member, mission));
 
-        if (member.isPushActivated() && mission.isHostMember(memberId)) {
-            eventPublisher.publishEvent(new JoinMissionEvent(mission.getId(), member.getDeviceToken(), member.getNickname()));
+        Long hostMemberId = mission.getHostMemberId();
+        Member hostMember = memberRepository.getMember(hostMemberId);
+        if (hostMember.isPushActivated() && !mission.isHostMember(memberId)) {
+            eventPublisher.publishEvent(
+                    new JoinMissionEvent(mission.getId(), hostMember.getDeviceToken(), member.getNickname())
+            );
         }
 
         // TODO: 추후 필요없으면 삭제

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
@@ -62,9 +62,12 @@ public class MissionMemberService {
         missionValidator.validateMaxPersonnel(mission);
         missionMemberRepository.save(MissionMember.join(member, mission));
 
-        if (member.isPushActivated()) {
+        if (member.isPushActivated() && mission.isHostMember(memberId)) {
             eventPublisher.publishEvent(new JoinMissionEvent(mission.getId(), member.getDeviceToken(), member.getNickname()));
-        } else {
+        }
+
+        // TODO: 추후 필요없으면 삭제
+        if (!member.isPushActivated()) {
             cancelRetryPushMessage(member.getId());
         }
     }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
@@ -62,15 +62,8 @@ public class MissionMemberService {
         missionValidator.validateMaxPersonnel(mission);
         missionMemberRepository.save(MissionMember.join(member, mission));
 
-        Long hostMemberId = mission.getHostMemberId();
-        Member hostMember = memberRepository.getMember(hostMemberId);
-        if (hostMember.isPushActivated() && !mission.isHostMember(memberId)) {
-            eventPublisher.publishEvent(
-                    new JoinMissionEvent(mission.getId(), hostMember.getDeviceToken(), member.getNickname())
-            );
-        }
+        sendJoinPushMessage(member, mission);
 
-        // TODO: 추후 필요없으면 삭제
         if (!member.isPushActivated()) {
             cancelRetryPushMessage(member.getId());
         }
@@ -86,6 +79,16 @@ public class MissionMemberService {
                 .ifPresent(missionMember -> {
                     throw new AlreadyExistsException(ErrorCode.ALREADY_EXISTS_MISSION_MEMBER);
                 });
+    }
+
+    private void sendJoinPushMessage(final Member member, final Mission mission) {
+        Member hostMember = memberRepository.getMember(mission.getHostMemberId());
+
+        if (hostMember.isPushActivated() && !mission.isHostMember(member.getId())) {
+            eventPublisher.publishEvent(
+                    new JoinMissionEvent(mission.getId(), hostMember.getDeviceToken(), member.getNickname())
+            );
+        }
     }
 
     public MissionsResponse findAllByMemberId(final Long memberId, final List<MissionStatus> filter) {

--- a/src/main/java/com/nexters/goalpanzi/common/aop/RedissonLockAspect.java
+++ b/src/main/java/com/nexters/goalpanzi/common/aop/RedissonLockAspect.java
@@ -12,8 +12,11 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 @Slf4j
 @Aspect

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -217,6 +217,16 @@ public class Mission extends BaseEntity {
         return today.isEqual(missionEndDate.toLocalDate());
     }
 
+    /**
+     * <b>미션 호스트인지 검증</b>
+     *
+     * @param memberId
+     * @return 미션 호스트(생성한 사람) 여부
+     */
+    public boolean isHostMember(final Long memberId) {
+        return hostMemberId == memberId;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/test/java/com/nexters/goalpanzi/application/mission/MissionMemberServiceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/MissionMemberServiceTest.java
@@ -1,14 +1,18 @@
 package com.nexters.goalpanzi.application.mission;
 
 import com.nexters.goalpanzi.application.firebase.TopicGenerator;
+import com.nexters.goalpanzi.application.mission.event.JoinMissionEvent;
 import com.nexters.goalpanzi.config.redis.RedisInitializer;
+import com.nexters.goalpanzi.domain.member.Member;
 import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
+import com.nexters.goalpanzi.domain.mission.InvitationCode;
 import com.nexters.goalpanzi.domain.mission.Mission;
 import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionRetryMessageRepository;
 import com.nexters.goalpanzi.infrastructure.firebase.PushMessageSender;
 import com.nexters.goalpanzi.infrastructure.firebase.TopicSubscriber;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,12 +20,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.nexters.goalpanzi.domain.firebase.PushMessage.MISSION_CANCELLATION_WARNING;
 import static com.nexters.goalpanzi.domain.firebase.PushMessage.MISSION_READY;
+import static com.nexters.goalpanzi.fixture.MemberFixture.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -30,9 +37,7 @@ import static org.mockito.Mockito.*;
         initializers = {RedisInitializer.class}
 )
 @MockBeans({
-        @MockBean(MemberRepository.class),
-        @MockBean(MissionRetryMessageRepository.class),
-        @MockBean(ApplicationEventPublisher.class)
+        @MockBean(MissionRetryMessageRepository.class)
 })
 class MissionMemberServiceTest {
 
@@ -49,12 +54,82 @@ class MissionMemberServiceTest {
     private MissionRepository missionRepository;
 
     @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private ApplicationEventPublisher eventPublisher;
+
+    @MockBean
     private PushMessageSender pushMessageSender;
 
     @MockBean
     private TopicSubscriber topicSubscriber;
 
     private static Long MISSION_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(
+                missionMemberService, "eventPublisher", eventPublisher
+        );
+    }
+
+    @Test
+    void 호스트가_아닌_멤버가_미션에_참여했을_때_JoinMissionEvent를_발행한다() {
+        InvitationCode INVITATION_CODE = InvitationCode.generate();
+        Long HOST_ID = MEMBER_ID + 1;
+
+        Member mockMember = mock(Member.class);
+        when(mockMember.getId()).thenReturn(MEMBER_ID);
+        when(mockMember.getNickname()).thenReturn(NICKNAME_MEMBER_A);
+
+        Member mockHostMember = mock(Member.class);
+        when(mockHostMember.getId()).thenReturn(HOST_ID);
+        when(mockHostMember.getDeviceToken()).thenReturn(DEVICE_TOKEN);
+        when(mockHostMember.isPushActivated()).thenReturn(true);
+
+        Mission mockMission = mock(Mission.class);
+        when(mockMission.getId()).thenReturn(MISSION_ID);
+        when(mockMission.getHostMemberId()).thenReturn(HOST_ID);
+        when(mockMission.isHostMember(MEMBER_ID)).thenReturn(false);
+
+        when(memberRepository.getMember(mockMember.getId())).thenReturn(mockMember);
+        when(memberRepository.getMember(mockHostMember.getId())).thenReturn(mockHostMember);
+
+        when(missionRepository.findByInvitationCode(INVITATION_CODE)).thenReturn(Optional.of(mockMission));
+        when(missionMemberRepository.findByMemberIdAndMissionId(MEMBER_ID, MISSION_ID)).thenReturn(Optional.empty());
+
+        missionMemberService.joinMission(MEMBER_ID, INVITATION_CODE);
+
+        verify(eventPublisher).publishEvent(
+                eq(new JoinMissionEvent(MISSION_ID, DEVICE_TOKEN, NICKNAME_MEMBER_A))
+        );
+    }
+
+    @Test
+    void 호스트가_미션에_참여했을_때_JoinMissionEvent를_발행하지_않는다() {
+        InvitationCode INVITATION_CODE = InvitationCode.generate();
+
+        Member mockMember = mock(Member.class);
+        when(mockMember.getId()).thenReturn(MEMBER_ID);
+        when(mockMember.getNickname()).thenReturn(NICKNAME_HOST);
+        when(mockMember.getDeviceToken()).thenReturn(DEVICE_TOKEN);
+        when(mockMember.isPushActivated()).thenReturn(true);
+
+        Mission mockMission = mock(Mission.class);
+        when(mockMission.getId()).thenReturn(MISSION_ID);
+        when(mockMission.getHostMemberId()).thenReturn(MEMBER_ID);
+        when(mockMission.isHostMember(MEMBER_ID)).thenReturn(true);
+
+        when(memberRepository.getMember(mockMember.getId())).thenReturn(mockMember);
+
+        when(missionRepository.findByInvitationCode(INVITATION_CODE)).thenReturn(Optional.of(mockMission));
+        when(missionMemberRepository.findByMemberIdAndMissionId(MEMBER_ID, MISSION_ID)).thenReturn(Optional.empty());
+
+        missionMemberService.joinMission(MEMBER_ID, INVITATION_CODE);
+
+        verifyNoInteractions(eventPublisher);
+    }
 
     @Test
     void 최소_인원을_채워_미션이_곧_시작될_경우_MISSION_READY_푸시_알림을_보낸다() {

--- a/src/test/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandlerTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/mission/event/handler/MissionMemberEventHandlerTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 class MissionMemberEventHandlerTest {
 
     @Autowired
-    private ApplicationEventPublisher applicationEventPublisher;
+    private ApplicationEventPublisher eventPublisher;
 
     @Autowired
     private TransactionTemplate transactionTemplate;
@@ -50,7 +50,7 @@ class MissionMemberEventHandlerTest {
         UpdateDeviceTokenEvent event = new UpdateDeviceTokenEvent(1L, null, "deviceToken");
 
         transactionTemplate.execute(status -> {
-            applicationEventPublisher.publishEvent(event);
+            eventPublisher.publishEvent(event);
             return null;
         });
 
@@ -63,7 +63,7 @@ class MissionMemberEventHandlerTest {
         UpdateDeviceTokenEvent event = new UpdateDeviceTokenEvent(1L, "deprecatedDeviceToken", "deviceToken");
 
         transactionTemplate.execute(status -> {
-            applicationEventPublisher.publishEvent(event);
+            eventPublisher.publishEvent(event);
             return null;
         });
 
@@ -78,7 +78,7 @@ class MissionMemberEventHandlerTest {
         UpdatePushActivationStatusEvent event = new UpdatePushActivationStatusEvent(1L, "deviceToken", true);
 
         transactionTemplate.execute(status -> {
-            applicationEventPublisher.publishEvent(event);
+            eventPublisher.publishEvent(event);
             return null;
         });
 
@@ -91,7 +91,7 @@ class MissionMemberEventHandlerTest {
         UpdatePushActivationStatusEvent event = new UpdatePushActivationStatusEvent(1L, "deviceToken", false);
 
         transactionTemplate.execute(status -> {
-            applicationEventPublisher.publishEvent(event);
+            eventPublisher.publishEvent(event);
             return null;
         });
 

--- a/src/test/java/com/nexters/goalpanzi/config/redisson/RedissonLockTestBean.java
+++ b/src/test/java/com/nexters/goalpanzi/config/redisson/RedissonLockTestBean.java
@@ -1,7 +1,9 @@
 package com.nexters.goalpanzi.config.redisson;
 
 import com.nexters.goalpanzi.common.annotation.RedissonLock;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 public class RedissonLockTestBean {
 
     @RedissonLock(waitTime = 1L)

--- a/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
+++ b/src/test/java/com/nexters/goalpanzi/domain/mission/MissionTest.java
@@ -250,4 +250,24 @@ class MissionTest {
                 () -> assertThat(mission.isEndDate(endDate.minusDays(1).toLocalDate())).isFalse()
         );
     }
+
+    @Test
+    void 미션_호스트_여부를_검증한다() {
+        LocalDateTime now = LocalDateTime.now();
+        Mission mission = Mission.create(
+                MEMBER_ID,
+                DESCRIPTION,
+                now,
+                now.plusDays(30),
+                TimeOfDay.EVERYDAY,
+                List.of(DayOfWeek.FRIDAY),
+                BOARD_COUNT,
+                InvitationCode.generate()
+        );
+
+        assertAll(
+                () -> assertThat(mission.isHostMember(MEMBER_ID)).isTrue(),
+                () -> assertThat(mission.isHostMember(MEMBER_ID + 1)).isFalse()
+        );
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,3 +45,10 @@ cloud:
 
 firebase:
   enabled: false
+
+logging:
+  level:
+    org:
+      springframework:
+        transaction:
+          interceptor: TRACE


### PR DESCRIPTION
## Issue Number

close: #

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
하루에 여러 번 미션 인증 방지 (#96)

+) MissionJoinEvent 수정

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 지난 번에 분산락을 이용해서 INSERT가 여러 번 일어나는 것을 막고자 했지만 같은 오류가 발생했습니다.
- 로그를 확인한 결과, 분산락 획득/습득은 순차적으로 이루어지고 있었습니다.
- 트랜잭션 로그를 활성화 시켰더니 `트랜잭션 시작 - 분산락 획득 - 분산락 반환 - 트랜잭션 커밋` 순서로 이루어졌습니다.
- 다음 그림과 같은 상황이 발생할 수 있다고 판단하여 `@Order`를 통해 `분산락 획득 - 트랜잭션 시작 - 트랜잭션 커밋 - 분산락 반환`이 이루어지도록 만들었습니다.

![image](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2Fci2RH8%2FbtsLeOUUBDW%2FDVuUpGXlTy8nUIy4s8kwk1%2Fimg.png)

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
분산락을 위한 트랜잭션을 하나 더 만들까 했다가 지금도 미션 인증할 때 시간이 많이 소요되어서 (뺑글이 많이 돌아감) 지양하는 것이 좋다고 판단했습니다....!

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
