### PR TITLE
fix: LoginEvent에서 디바이스를 찾지 못하는 오류 수정

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/device/DeviceSubscriptionService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/device/DeviceSubscriptionService.java
@@ -95,7 +95,12 @@ public class DeviceSubscriptionService {
      */
     @Transactional
     public void subscribeToMyMissions(final Long memberId, final String deviceIdentifier) {
-        Device device = deviceRepository.getDevice(memberId, deviceIdentifier);
+        Device device = deviceRepository.findByMemberIdAndDeviceIdentifier(memberId, deviceIdentifier)
+                .orElse(null);
+        if (device == null) {
+            return;
+        }
+
         List<String> topics = findMySubscribedTopics(device.getId());
         List<Mission> missions = missionRepository.findAllById(
                 findMySubscribableMission(memberId, topics)

--- a/src/main/java/com/nexters/goalpanzi/application/device/event/UpdateDeviceTokenEvent.java
+++ b/src/main/java/com/nexters/goalpanzi/application/device/event/UpdateDeviceTokenEvent.java
@@ -5,4 +5,8 @@ public record UpdateDeviceTokenEvent(
         Long deviceId,
         String deprecatedDeviceToken
 ) {
+
+    public boolean isTokenDeprecated() {
+        return deprecatedDeviceToken != null;
+    }
 }

--- a/src/main/java/com/nexters/goalpanzi/application/device/event/handler/DeviceSubscriptionEventHandler.java
+++ b/src/main/java/com/nexters/goalpanzi/application/device/event/handler/DeviceSubscriptionEventHandler.java
@@ -4,6 +4,8 @@ import com.nexters.goalpanzi.application.auth.event.LoginEvent;
 import com.nexters.goalpanzi.application.device.DeviceSubscriptionService;
 import com.nexters.goalpanzi.application.device.event.UpdateDeviceTokenEvent;
 import com.nexters.goalpanzi.application.device.event.UpdatePushActivationStatusEvent;
+import com.nexters.goalpanzi.application.mission.event.SubscribeToMissionEvent;
+import com.nexters.goalpanzi.application.mission.event.UnsubscribeFromMissionEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -24,7 +26,7 @@ public class DeviceSubscriptionEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     void handleUpdateDeviceTokenEvent(final UpdateDeviceTokenEvent event) {
-        if (event.deprecatedDeviceToken() != null) {
+        if (event.isTokenDeprecated()) {
             deviceSubscriptionService.unsubscribeFromMyMissions(event.memberId(), event.deviceId(), event.deprecatedDeviceToken());
         }
         deviceSubscriptionService.subscribeToMyMissions(event.memberId(), event.deviceId());
@@ -52,4 +54,17 @@ public class DeviceSubscriptionEventHandler {
         log.info("Handled LoginEvent for memberId: {}", event.memberId());
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void handleSubscribeMissionEvent(final SubscribeToMissionEvent event) {
+        deviceSubscriptionService.subscribeToMission(event.memberId(), event.mission());
+        log.info("Handled SubscribeMissionEvent for memberId: {} and missionId: {}", event.memberId(), event.mission().getId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void handleUnsubscribeFromMissionEvent(final UnsubscribeFromMissionEvent event) {
+        deviceSubscriptionService.unsubscribeFromMission(event.missionId());
+        log.info("Handled UnsubscribeMissionEvent from missionId: {}", event.missionId());
+    }
 }

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/event/handler/PushMessageEventHandler.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/event/handler/PushMessageEventHandler.java
@@ -1,11 +1,8 @@
 package com.nexters.goalpanzi.application.firebase.event.handler;
 
-import com.nexters.goalpanzi.application.device.DeviceSubscriptionService;
 import com.nexters.goalpanzi.application.firebase.TopicGenerator;
 import com.nexters.goalpanzi.application.mission.event.CompleteMissionEvent;
 import com.nexters.goalpanzi.application.mission.event.JoinMissionEvent;
-import com.nexters.goalpanzi.application.mission.event.SubscribeToMissionEvent;
-import com.nexters.goalpanzi.application.mission.event.UnsubscribeFromMissionEvent;
 import com.nexters.goalpanzi.infrastructure.firebase.PushMessageSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +21,6 @@ import static com.nexters.goalpanzi.domain.firebase.PushMessage.MISSION_JOINED;
 @RequiredArgsConstructor
 @Component
 public class PushMessageEventHandler {
-
-    private final DeviceSubscriptionService deviceSubscriptionService;
 
     private final PushMessageSender pushMessageSender;
 
@@ -58,19 +53,5 @@ public class PushMessageEventHandler {
                 topic
         );
         log.info("Handled CompleteMissionEvent for missionId: {}", event.missionId());
-    }
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    void handleSubscribeMissionEvent(final SubscribeToMissionEvent event) {
-        deviceSubscriptionService.subscribeToMission(event.memberId(), event.mission());
-        log.info("Handled SubscribeMissionEvent for memberId: {} and missionId: {}", event.memberId(), event.mission().getId());
-    }
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    void handleUnsubscribeFromMissionEvent(final UnsubscribeFromMissionEvent event) {
-        deviceSubscriptionService.unsubscribeFromMission(event.missionId());
-        log.info("Handled UnsubscribeMissionEvent from missionId: {}", event.missionId());
     }
 }

--- a/src/test/java/com/nexters/goalpanzi/application/device/DeviceSubscriptionServiceTest.java
+++ b/src/test/java/com/nexters/goalpanzi/application/device/DeviceSubscriptionServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.nexters.goalpanzi.domain.mission.MissionStatus.CREATED;
 import static com.nexters.goalpanzi.fixture.DeviceFixture.DEVICE_IDENTIFIER;
@@ -132,7 +133,7 @@ class DeviceSubscriptionServiceTest {
         DeviceSubscription mockDeviceSubscription = mock(DeviceSubscription.class);
         when(mockDeviceSubscription.getMission()).thenReturn(mockSubscribedMission);
 
-        when(deviceRepository.getDevice(MEMBER_ID, DEVICE_IDENTIFIER)).thenReturn(mockDevice);
+        when(deviceRepository.findByMemberIdAndDeviceIdentifier(MEMBER_ID, DEVICE_IDENTIFIER)).thenReturn(Optional.of(mockDevice));
         when(deviceSubscriptionRepository.findAllWithMissionAndDeviceByDeviceId(DEVICE_ID))
                 .thenReturn(List.of(mockDeviceSubscription));
 


### PR DESCRIPTION
## Issue Number

close: #

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

(#108)
`LoginEvent`에서 디바이스 식별자를 전달하게 되는데, 사전에 디바이스 토큰을 업데이트하지 않은 사용자는 디바이스 레코드가 존재하지 않아 404 오류가 발생한다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
디바이스가 없는 경우에 대해 분기 처리를 진행했습니다.
```java
Device device = deviceRepository.findByMemberIdAndDeviceIdentifier(memberId, deviceIdentifier)
    .orElse(null);
if (device == null) {
    return;
}
```

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
