### PR TITLE
fix: 미션 조인 푸시 알림

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - fix/#115-join-push
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - fix/#115-join-push
 
 jobs:
   build-and-push:

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/PushMessageSenderImpl.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/PushMessageSenderImpl.java
@@ -85,7 +85,7 @@ public class PushMessageSenderImpl implements PushMessageSender {
             FirebaseMessaging.getInstance().send(message);
         } catch (FirebaseMessagingException e) {
             if (e.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
-                log.error(e.getMessage());
+                log.info("더 이상 사용되지 않는 토큰입니다.");
             } else {
                 throw new BaseException(errorCode, e);
             }

--- a/src/main/java/com/nexters/goalpanzi/application/firebase/PushMessageSenderImpl.java
+++ b/src/main/java/com/nexters/goalpanzi/application/firebase/PushMessageSenderImpl.java
@@ -1,16 +1,15 @@
 package com.nexters.goalpanzi.application.firebase;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.*;
 import com.nexters.goalpanzi.exception.BaseException;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.infrastructure.firebase.PushMessageSender;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+@Slf4j
 @Component
 public class PushMessageSenderImpl implements PushMessageSender {
 
@@ -85,7 +84,11 @@ public class PushMessageSenderImpl implements PushMessageSender {
         try {
             FirebaseMessaging.getInstance().send(message);
         } catch (FirebaseMessagingException e) {
-            throw new BaseException(errorCode, e);
+            if (e.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
+                log.error(e.getMessage());
+            } else {
+                throw new BaseException(errorCode, e);
+            }
         }
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionMemberService.java
@@ -20,7 +20,6 @@ import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.NotFoundException;
 import com.nexters.goalpanzi.infrastructure.firebase.PushMessageSender;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +32,6 @@ import java.util.Map;
 import static com.nexters.goalpanzi.domain.firebase.PushMessage.MISSION_CANCELLATION_WARNING;
 import static com.nexters.goalpanzi.domain.firebase.PushMessage.MISSION_READY;
 
-@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -84,12 +82,7 @@ public class MissionMemberService {
                 });
     }
 
-    // FIXME: 호스트에게 알림 가는 데 확인 필요
     private void sendJoinPushMessage(final Member member, final Mission mission) {
-        // TODO: 오류 확인 후 삭제
-        log.info("Host member: " + mission.getHostMemberId());
-        log.info("Join member: " + member.getId());
-
         if (mission.isHostMember(member.getId())) {
             return;
         }

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/Mission.java
@@ -220,11 +220,11 @@ public class Mission extends BaseEntity {
     /**
      * <b>미션 호스트인지 검증</b>
      *
-     * @param memberId
+     * @param memberId 멤버 아이디
      * @return 미션 호스트(생성한 사람) 여부
      */
     public boolean isHostMember(final Long memberId) {
-        return hostMemberId == memberId;
+        return hostMemberId.equals(memberId);
     }
 
     @Override


### PR DESCRIPTION
## Issue Number

close: #115

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
호스트에게 본인의 푸시 알림이 가지 않도록 수정했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- `equals`로 변경하여 값을 비교하도록 수정했습니다.
- (다른 이슈) 빌드/릴리즈 환경에 따라 디바이스 식별자가 달라져 더 이상 유효하지 않은 디바이스 토큰으로 알림이 가는 상황이 발생했습니다. (`MessagingErrorCode UNREGISTERED`) 해당 에러가 발생한 경우는 예외를 던지지 않도록 구현했습니다. 

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
