### PR TITLE
feat: 내기록 탭 > 미션별 내 상세 기록 조회 API

### DIFF
--- a/src/main/java/com/nexters/goalpanzi/application/history/HistoryService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/history/HistoryService.java
@@ -74,7 +74,7 @@ public class HistoryService {
                         it.getImageUrl(),
                         it.getCreatedAt()))
                 .toList();
-        Long totalCount = missionVerificationRepository.countByMemberIdAndMissionId(memberId, missionId);
+        long totalCount = missionVerificationRepository.countByMemberIdAndMissionId(memberId, missionId);
 
         return HistoryResponse.VerificationWrapper.builder()
                 .totalCount(totalCount)

--- a/src/main/java/com/nexters/goalpanzi/application/history/HistoryService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/history/HistoryService.java
@@ -1,6 +1,8 @@
 package com.nexters.goalpanzi.application.history;
 
 import com.nexters.goalpanzi.application.history.dto.response.HistoryResponse;
+import com.nexters.goalpanzi.domain.member.Member;
+import com.nexters.goalpanzi.domain.member.repository.MemberRepository;
 import com.nexters.goalpanzi.domain.mission.Mission;
 import com.nexters.goalpanzi.domain.mission.MissionMember;
 import com.nexters.goalpanzi.domain.mission.MissionStatus;
@@ -26,6 +28,7 @@ public class HistoryService {
     private final MissionRepository missionRepository;
     private final MissionMemberRepository missionMemberRepository;
     private final MissionVerificationRepository missionVerificationRepository;
+    private final MemberRepository memberRepository;
 
     public HistoryResponse.CompletedMissionWrapper getMissionHistories(
             final Long memberId,
@@ -56,7 +59,30 @@ public class HistoryService {
                 totalCount,
                 histories
         );
+    }
 
+    public HistoryResponse.VerificationWrapper getMissionVerificationHistories(
+            final Long missionId,
+            final Long memberId,
+            final PageRequest pageRequest
+    ) {
+        Mission mission = missionRepository.getMission(missionId);
+        Member member = memberRepository.getMember(memberId);
+        var missionVerifications = missionVerificationRepository.findByMemberIdAndMissionId(memberId, missionId, pageRequest)
+                .stream()
+                .map(it -> new HistoryResponse.Verification(
+                        it.getImageUrl(),
+                        it.getCreatedAt()))
+                .toList();
+        Long totalCount = missionVerificationRepository.countByMemberIdAndMissionId(memberId, missionId);
+
+        return HistoryResponse.VerificationWrapper.builder()
+                .totalCount(totalCount)
+                .nickname(member.getNickname())
+                .missionId(mission.getId())
+                .description(mission.getDescription())
+                .verifications(missionVerifications)
+                .build();
     }
 
     private List<Long> getCompletedMissionIds(final List<MissionMember> completedMissionMembers) {

--- a/src/main/java/com/nexters/goalpanzi/application/history/dto/response/HistoryResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/history/dto/response/HistoryResponse.java
@@ -78,11 +78,36 @@ public class HistoryResponse {
 
             return CompletedMission.of(
                     mission,
-                    verifications.getRandomImageUrl(),
+                    verifications.getRandomImageUrlOrNull(),
                     verifications.count(),
                     missionMembers.size(),
                     memberRanks.getRankByMemberId(memberId).rank()
             );
         }
+    }
+
+    @Builder
+    public record VerificationWrapper(
+            @Schema(description = "총 개수", requiredMode = Schema.RequiredMode.REQUIRED)
+            Long totalCount,
+            @Schema(description = "닉네임", requiredMode = Schema.RequiredMode.REQUIRED)
+            String nickname,
+            @Schema(description = "미션 ID", requiredMode = Schema.RequiredMode.REQUIRED)
+            Long missionId,
+            @Schema(description = "미션 이름 (목표 행동)", requiredMode = Schema.RequiredMode.REQUIRED)
+            String description,
+            @Schema(description = "미션 인증 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+            List<Verification> verifications
+    ) {
+
+    }
+
+    public record Verification(
+            @Schema(description = "인증 이미지 URL", requiredMode = Schema.RequiredMode.REQUIRED)
+            String imageUrl,
+            @Schema(description = "인증 날짜", requiredMode = Schema.RequiredMode.REQUIRED)
+            LocalDateTime date
+    ) {
+
     }
 }

--- a/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/MissionBoardService.java
@@ -10,15 +10,18 @@ import com.nexters.goalpanzi.domain.mission.repository.MissionMemberRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionRepository;
 import com.nexters.goalpanzi.domain.mission.repository.MissionVerificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.text.html.Option;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -38,16 +41,32 @@ public class MissionBoardService {
         MissionMembers missionMembers = getMissionMembers(query.missionId(), query.sortType(), query.direction());
         missionMembers.verifyMissionMember(member);
 
+        // key: 보드칸 번호 value: 참여 멤버 목록
         Map<Integer, List<Member>> boardMap = groupByVerificationCount(mission, missionMembers);
-        List<MissionBoardResponse> boards = new ArrayList<>();
-        for (Map.Entry<Integer, List<Member>> entry : boardMap.entrySet()) {
-            boards.add(MissionBoardResponse.of(query.memberId(), entry.getKey(), entry.getValue()));
-        }
+
+        // key: 보드칸 번호 value: 미션 인증 정보
+        Map<Integer, MissionVerification> boardCountMap = missionVerificationRepository.findByMemberIdAndMissionId(
+                        member.getId(), mission.getId(), Pageable.unpaged())
+                .stream()
+                .collect(Collectors.toMap(MissionVerification::getBoardNumber, verification -> verification));
+
+        var boards = boardMap.entrySet().stream()
+                .map(board -> generateBoardInfo(query.memberId(), board, boardCountMap.getOrDefault(board.getKey(), null)))
+                .toList();
 
         return new MissionBoardsResponse(
                 getProgressCount(query.missionId()),
                 MemberRanks.from(missionMembers.getMissionMembers()).getRankByMember(member).rank(),
                 boards);
+    }
+
+    private MissionBoardResponse generateBoardInfo(final Long memberId, final Map.Entry<Integer, List<Member>> board,
+                                                   final MissionVerification missionVerification) {
+        var imageUrl = Optional.ofNullable(missionVerification)
+                .map(MissionVerification::getImageUrl)
+                .orElse(null);
+
+        return MissionBoardResponse.of(memberId, board.getKey(), board.getValue(), imageUrl);
     }
 
     private MissionMembers getMissionMembers(final Long missionId, final MissionBoardQuery.SortType sortType, final Sort.Direction direction) {

--- a/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
+++ b/src/main/java/com/nexters/goalpanzi/application/mission/dto/response/MissionBoardResponse.java
@@ -15,15 +15,21 @@ public record MissionBoardResponse(
         Reward reward,
         @Schema(description = "내 장기말 존재 여부", requiredMode = Schema.RequiredMode.REQUIRED)
         Boolean isMyPosition,
+        @Schema(description = "인증 이미지 URL (없으면 NULL)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String myVerificationImageUrl,
         @Schema(description = "해당 보드칸에 존재하는 장기말", requiredMode = Schema.RequiredMode.REQUIRED)
         List<MissionBoardMemberResponse> missionBoardMembers
 ) {
 
-    public static MissionBoardResponse of(final Long memberId, final Integer number, final List<Member> members) {
+    public static MissionBoardResponse of(
+            final Long memberId, final Integer number,
+            final List<Member> members, final String verificationImageUrl
+    ) {
         return new MissionBoardResponse(
                 number,
                 Reward.of(number),
                 isMyPosition(memberId, members),
+                verificationImageUrl,
                 members.stream()
                         .map(MissionBoardMemberResponse::from)
                         .collect(Collectors.toList())

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/MissionVerifications.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/MissionVerifications.java
@@ -11,7 +11,7 @@ public class MissionVerifications {
     private static final Random RANDOM = new Random();
     private final List<MissionVerification> missionVerifications;
 
-    public String getRandomImageUrl() {
+    public String getRandomImageUrlOrNull() {
         if (missionVerifications.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/repository/MissionMemberRepository.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/repository/MissionMemberRepository.java
@@ -41,7 +41,7 @@ public interface MissionMemberRepository extends JpaRepository<MissionMember, Lo
             final Pageable pageable
     );
 
-    Long countByMemberIdAndMissionStatus(final Long memberId, final MissionStatus status);
+    long countByMemberIdAndMissionStatus(final Long memberId, final MissionStatus status);
 
     default MissionMember getMissionMember(final Long memberId, final Long missionId) {
         return findByMemberIdAndMissionId(memberId, missionId)

--- a/src/main/java/com/nexters/goalpanzi/domain/mission/repository/MissionVerificationRepository.java
+++ b/src/main/java/com/nexters/goalpanzi/domain/mission/repository/MissionVerificationRepository.java
@@ -3,6 +3,7 @@ package com.nexters.goalpanzi.domain.mission.repository;
 import com.nexters.goalpanzi.domain.mission.MissionVerification;
 import com.nexters.goalpanzi.exception.ErrorCode;
 import com.nexters.goalpanzi.exception.NotFoundException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -29,6 +30,10 @@ public interface MissionVerificationRepository extends JpaRepository<MissionVeri
     Optional<MissionVerification> findByMemberIdAndMissionIdAndDate(Long memberId, Long missionId, LocalDate date);
 
     List<MissionVerification> findByMemberIdAndMissionIdIn(final Long memberId, final List<Long> missionIds);
+
+    List<MissionVerification> findByMemberIdAndMissionId(final Long memberId, final Long missionId, final Pageable pageable);
+
+    long countByMemberIdAndMissionId(final Long memberId, final Long missionId);
 
     default MissionVerification getMyVerification(final Long memberId, final Long missionId, final Integer boardNumber) {
         return findByMemberIdAndMissionIdAndBoardNumber(memberId, missionId, boardNumber)

--- a/src/main/java/com/nexters/goalpanzi/presentation/history/HistoryController.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/history/HistoryController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +18,7 @@ public class HistoryController implements HistoryControllerDocs {
     private final HistoryService historyService;
 
     @Override
-    @GetMapping("/api/missions/history")
+    @GetMapping("/api/missions/histories/me")
     public ResponseEntity<HistoryResponse.CompletedMissionWrapper> getMyMissionHistories(
             @LoginMemberId final Long memberId,
             @RequestParam(defaultValue = "0") final Integer page,
@@ -27,4 +28,20 @@ public class HistoryController implements HistoryControllerDocs {
 
         return ResponseEntity.ok(result);
     }
+
+    @Override
+    @GetMapping("/api/missions/{missionId}/histories/me")
+    public ResponseEntity<HistoryResponse.VerificationWrapper> getMyVerifications(
+            @PathVariable final Long missionId,
+            @LoginMemberId final Long memberId,
+            @RequestParam(defaultValue = "0") final Integer page,
+            @RequestParam(defaultValue = "30") final Integer pageSize
+    ) {
+        var result = historyService.getMissionVerificationHistories(
+                missionId, memberId, PageRequest.of(page, pageSize)
+        );
+
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/src/main/java/com/nexters/goalpanzi/presentation/history/HistoryControllerDocs.java
+++ b/src/main/java/com/nexters/goalpanzi/presentation/history/HistoryControllerDocs.java
@@ -11,8 +11,20 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "내 기록 (히스토리)")
 public interface HistoryControllerDocs {
 
-    @Operation(summary = "내 완료 미션 기록 조회")
+    @Operation(summary = "완료한 미션 목록 조회")
     ResponseEntity<HistoryResponse.CompletedMissionWrapper> getMyMissionHistories(
+            @Parameter(in = ParameterIn.HEADER, hidden = true)
+            final Long memberId,
+            @Schema(description = "페이지 번호 (default:0)")
+            final Integer page,
+            @Schema(description = "페이지 사이즈 (default:30)")
+            final Integer pageSize
+    );
+
+    @Operation(summary = "미션 별 인증 기록 조회")
+    ResponseEntity<HistoryResponse.VerificationWrapper> getMyVerifications(
+            @Schema(description = "미션 ID")
+            final Long missionId,
             @Parameter(in = ParameterIn.HEADER, hidden = true)
             final Long memberId,
             @Schema(description = "페이지 번호 (default:0)")


### PR DESCRIPTION
## Issue Number

close: #117 

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->


## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 내기록 탭 > 미션별 내 상세 기록 조회 API
- 보드판 조회시 미션 인증 이미지 URL 응답 추가 (스토리 기능 좌우 스와이프 위함)

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
